### PR TITLE
Moved YouTubeDL provider

### DIFF
--- a/lua/entities/gmod_tardis/modules/cl_music.lua
+++ b/lua/entities/gmod_tardis/modules/cl_music.lua
@@ -32,7 +32,7 @@ local patterns={
 	"youtu.be/([_A-Za-z0-9-]+)",
 	"youtube.com/watch%?v=([_A-Za-z0-9-]+)",
 }
-local api="https://abyss.mattjeanes.com:8090/"
+local api="https://youtubedl.mattjeanes.com/"
 function ENT:ResolveMusicURL(url)
 	if url:find("youtu.be") or url:find("youtube.com") then
 		local id=string.match(url,patterns[1]) or string.match(url,patterns[2])


### PR DESCRIPTION
Moved YouTubeDL provider from  from https://abyss.mattjeanes.com:8090 to https://youtubedl.mattjeanes.com to keep it working when the original server shuts down in the next weeks.

This addon is in [Extended Support](https://steamcommunity.com/workshop/filedetails/discussion/307175678/1733212454825614492/) - only updates to keep it working will be made when broken by GMod updates etc.