### PR TITLE
Further health fixes

### DIFF
--- a/lua/entities/gmod_tardis/init.lua
+++ b/lua/entities/gmod_tardis/init.lua
@@ -35,5 +35,6 @@ function ENT:PhysicsCollide(colData, collider)
 	self:CallHook("PhysicsCollide", colData, collider)
 end
 function ENT:OnTakeDamage(dmginfo)
+	if self:CallHook("ShouldTakeDamage",dmginfo)==false then return end
 	self:CallHook("OnTakeDamage", dmginfo)
 end

--- a/lua/entities/gmod_tardis/modules/sh_hads.lua
+++ b/lua/entities/gmod_tardis/modules/sh_hads.lua
@@ -10,6 +10,7 @@ function ENT:ToggleHADS()
 end
 
 ENT:AddHook("OnTakeDamage", "hads", function(self)
+	if self:CallHook("CanTriggerHads")==false then return end
 	if (self:GetData("hads",false)==true and self:GetData("hads-triggered",false)==false) and (not self:GetData("teleport",false)) then
 		self:GetCreator():ChatPrint("Your TARDIS is under attack and the HADS has been triggered!")
 		self:SetData("hads-triggered",true,true)

--- a/lua/entities/gmod_tardis/modules/sv_power.lua
+++ b/lua/entities/gmod_tardis/modules/sv_power.lua
@@ -17,4 +17,8 @@ if SERVER then
             self.interior:CallHook("PowerToggled",on)
         end
     end
+
+    ENT:AddHook("CanTriggerHads","power",function(self)
+        if not self:GetData("power-state",false) then return false end
+    end)
 end

--- a/lua/entities/gmod_tardis_interior/init.lua
+++ b/lua/entities/gmod_tardis_interior/init.lua
@@ -27,5 +27,6 @@ function ENT:Initialize()
 end
 
 function ENT:OnTakeDamage(dmginfo)
+	if self:CallHook("ShouldTakeDamage",dmginfo)==false then return end
 	self:CallHook("OnTakeDamage", dmginfo)
 end

--- a/lua/entities/gmod_tardis_interior/modules/sv_health.lua
+++ b/lua/entities/gmod_tardis_interior/modules/sv_health.lua
@@ -15,3 +15,7 @@ ENT:AddHook("health-depleted", "interior-death", function(self)
     util.ScreenShake(self:GetPos(), 10, 10, 1, 10)
     self:Explode()
 end)
+
+ENT:AddHook("ShouldTakeDamage", "DamageOff", function(self, dmginfo)
+    if not TARDIS:GetSetting("health-enabled") then return false end
+end)

--- a/lua/entities/gmod_tardis_part/init.lua
+++ b/lua/entities/gmod_tardis_part/init.lua
@@ -3,5 +3,6 @@ AddCSLuaFile('shared.lua')
 include('shared.lua')
 
 function ENT:OnTakeDamage(dmginfo)
+	if self.parent:CallHook("ShouldTakeDamage",dmginfo)==false then return end
 	self.parent:CallHook("OnTakeDamage", dmginfo)
 end

--- a/lua/tardis/sh_menuoptions.lua
+++ b/lua/tardis/sh_menuoptions.lua
@@ -29,7 +29,7 @@ if CLIENT then
 else
 	util.AddNetworkString("TARDIS-DamageCvar")
 
-	net.Receive("TARDIS-SvCvars", function(len, ply)
+	net.Receive("TARDIS-DamageCvar", function(len, ply)
 		if ply:IsAdmin() or ply:IsSuperAdmin() then
 			local val = net.ReadBool()
 			RunConsoleCommand( "tardis2_damage", tostring(val) )


### PR DESCRIPTION
- Max health can no longer be negative
- HADS can no longer be triggered with the power off
- The damage toggle checkbox was fixed
- Damage disabled checks were moved to a hook and off the ChangeHealth function
- Repair no longer works when damage is off and will just replenish health.