### PR TITLE
Health detail pass & QOL Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 lua/TARDIS-Rewrite.code-workspace
+lua/.vscode/settings.json

--- a/lua/entities/gmod_tardis/modules/cl_projectedlight.lua
+++ b/lua/entities/gmod_tardis/modules/cl_projectedlight.lua
@@ -1,0 +1,63 @@
+
+TARDIS:AddSetting({
+	id="extprojlight-enabled",
+	name="Door Light Enabled",
+	section="Misc",
+	desc="Should light shine out through the doors when they're open?",
+	value=true,
+	type="bool",
+	option=true,
+	networked=true
+})
+
+function ENT:CalcLightBrightness()
+    local lightcolour = render.GetLightColor(self:GetPos()):ToColor()
+    local rm = 0.299*lightcolour.r
+    local gm = 0.587*lightcolour.g
+    local bm = 0.114*lightcolour.b
+    local luminance = rm + gm + rm
+    return luminance
+end
+
+ENT:AddHook("Initialize", "projectedlight", function(self)
+    self.projectedlight = ProjectedTexture()
+    self.projectedlight:SetTexture("effects/flashlight/square")
+    self.projectedlight:SetFarZ(250)
+    self.projectedlight:SetVerticalFOV(self.metadata.Exterior.Portal.height)
+    self.projectedlight:SetHorizontalFOV(self.metadata.Exterior.Portal.width+10)
+    self.projectedlight:SetColor(self.metadata.Interior.Light.color)
+    --self.projectedlight:SetBrightness(0.5)
+	self.projectedlight:SetPos(self:LocalToWorld(Vector(0,0,50)))
+	self.projectedlight:SetAngles(self:GetAngles())
+	self.projectedlight:Update()
+end)
+
+ENT:AddHook("OnRemove", "projectedlight", function(self)
+	if ( IsValid( self.projectedlight ) ) then
+		self.projectedlight:Remove()
+	end
+end)
+
+ENT:AddHook("Think", "projectedlight", function(self)
+    if (not TARDIS:GetSetting("extprojlight-enabled")) then
+        if self.projectedlight:GetEnableShadows() == true then 
+            self.projectedlight:SetEnableShadows(false)
+            self.projectedlight:SetBrightness(0)
+            self.projectedlight:Update()
+        end
+        return
+    end
+    if self.projectedlight:GetBrightness() > 0 and not self:DoorOpen(true) then
+        self.projectedlight:SetEnableShadows(false)
+        self.projectedlight:SetBrightness(0)
+        self.projectedlight:Update()
+    elseif self:DoorOpen(true) and self.projectedlight:GetBrightness() == 0 then
+        self.projectedlight:SetEnableShadows(true)
+        self.projectedlight:SetBrightness(0.5)
+    end
+    if ( IsValid( self.projectedlight ) ) and self:DoorOpen(true) then
+		self.projectedlight:SetPos( self:LocalToWorld(Vector(-25,0,51.1)) )
+		self.projectedlight:SetAngles( self:LocalToWorldAngles(Angle(0,0,0)) )
+		self.projectedlight:Update()
+	end
+end)

--- a/lua/entities/gmod_tardis/modules/cl_projectedlight.lua
+++ b/lua/entities/gmod_tardis/modules/cl_projectedlight.lua
@@ -20,6 +20,7 @@ function ENT:CalcLightBrightness()
 end
 
 ENT:AddHook("Initialize", "projectedlight", function(self)
+    self.projlightsettings = {}
     self.projectedlight = ProjectedTexture()
     self.projectedlight:SetTexture("effects/flashlight/square")
     self.projectedlight:SetFarZ(250)
@@ -28,7 +29,9 @@ ENT:AddHook("Initialize", "projectedlight", function(self)
     self.projectedlight:SetColor(self.metadata.Interior.Light.color)
     --self.projectedlight:SetBrightness(0.5)
 	self.projectedlight:SetPos(self:LocalToWorld(Vector(0,0,50)))
-	self.projectedlight:SetAngles(self:GetAngles())
+    self.projectedlight:SetAngles(self:GetAngles())
+    self.projlightsettings.basebrightness = 1
+    self.projlightsettings.calculatedbrightness = self.projlightsettings.basebrightness
 	self.projectedlight:Update()
 end)
 
@@ -38,8 +41,12 @@ ENT:AddHook("OnRemove", "projectedlight", function(self)
 	end
 end)
 
+ENT:AddHook("ShouldDrawProjectedLight", "setting", function(self)
+    if (not TARDIS:GetSetting("extprojlight-enabled")) then return false end
+end)
+
 ENT:AddHook("Think", "projectedlight", function(self)
-    if (not TARDIS:GetSetting("extprojlight-enabled")) then
+    if (self:CallHook("ShouldDrawProjectedLight")==false) then
         if self.projectedlight:GetEnableShadows() == true then 
             self.projectedlight:SetEnableShadows(false)
             self.projectedlight:SetBrightness(0)
@@ -53,7 +60,7 @@ ENT:AddHook("Think", "projectedlight", function(self)
         self.projectedlight:Update()
     elseif self:DoorOpen(true) and self.projectedlight:GetBrightness() == 0 then
         self.projectedlight:SetEnableShadows(true)
-        self.projectedlight:SetBrightness(0.5)
+        self.projectedlight:SetBrightness(self.projlightsettings.calculatedbrightness)
     end
     if ( IsValid( self.projectedlight ) ) and self:DoorOpen(true) then
 		self.projectedlight:SetPos( self:LocalToWorld(Vector(-25,0,51.1)) )

--- a/lua/entities/gmod_tardis/modules/cl_projectedlight.lua
+++ b/lua/entities/gmod_tardis/modules/cl_projectedlight.lua
@@ -1,4 +1,5 @@
-
+--Fake light bleeding
+--Settings
 TARDIS:AddSetting({
 	id="extprojlight-enabled",
 	name="Door Light Enabled",
@@ -7,68 +8,73 @@ TARDIS:AddSetting({
 	value=true,
 	type="bool",
 	option=true,
-	networked=true
 })
-
-function ENT:CalcLightBrightness(interior)
-    local pos = (interior and self.interior:GetPos() or self:GetPos())
-    local lightcolour = render.GetLightColor(pos):ToColor()
-    local rm = 0.299*lightcolour.r
-    local gm = 0.587*lightcolour.g
-    local bm = 0.114*lightcolour.b
-    local luminance = rm + gm + rm
-    return luminance
+--Methods
+function ENT:CalcLightBrightness(pos)
+	local lightcolour = render.GetLightColor(pos):ToColor()
+	local rm = 0.299*lightcolour.r
+	local gm = 0.587*lightcolour.g
+	local bm = 0.114*lightcolour.b
+	local luminance = rm + gm + rm
+	return luminance
 end
 
-ENT:AddHook("Initialize", "projectedlight", function(self)
-    if not self.interior then return end
-    self.projlightsettings = {}
-    self.projectedlight = ProjectedTexture()
-    self.projectedlight:SetTexture("effects/flashlight/square")
-    self.projectedlight:SetFarZ(250)
-    self.projectedlight:SetVerticalFOV(self.metadata.Exterior.Portal.height)
-    self.projectedlight:SetHorizontalFOV(self.metadata.Exterior.Portal.width+10)
-    self.projectedlight:SetColor(self.metadata.Interior.Light.color)
-    --self.projectedlight:SetBrightness(0.5)
-	self.projectedlight:SetPos(self:LocalToWorld(Vector(0,0,50)))
-    self.projectedlight:SetAngles(self:GetAngles())
-    self.projlightsettings.basebrightness = 0.5
-    self.projlightsettings.calculatedbrightness = self.projlightsettings.basebrightness
-	self.projectedlight:Update()
-end)
+function ENT:CreateProjectedLight()
+	if self.projectedlight then return end
+	local pl = ProjectedTexture()
+	pl:SetTexture("effects/flashlight/square")
+	pl:SetFarZ(250)
+	pl:SetVerticalFOV(self.metadata.Exterior.Portal.height)
+	pl:SetHorizontalFOV(self.metadata.Exterior.Portal.width+10)
+	pl:SetColor(self.metadata.Interior.Light.color)
+    pl:SetBrightness(0.5)
+    pl:SetPos(self:LocalToWorld(Vector(-21,0,51.1)))
+    pl:SetEnableShadows(true)
+	pl:SetAngles(self:GetAngles())
+	pl:Update()
+	self.projectedlight = pl
+end
 
+function ENT:RemoveProjectedLight()
+	if self.projectedlight then
+		self.projectedlight:Remove()
+		self.projectedlight = nil
+	end
+end
+
+function ENT:UpdateProjectedLight()
+    self.projectedlight:SetPos(self:LocalToWorld(Vector(-21,0,51.1)))
+    self.projectedlight:SetAngles(self:GetAngles())
+    self.projectedlight:Update()
+end
+--Hooks
 ENT:AddHook("OnRemove", "projectedlight", function(self)
 	if ( IsValid( self.projectedlight ) ) then
 		self.projectedlight:Remove()
 	end
 end)
 
-ENT:AddHook("ShouldDrawProjectedLight", "setting", function(self)
-    if (not TARDIS:GetSetting("extprojlight-enabled")) then return false end
+ENT:AddHook("ShouldDrawProjectedLight", "baseShouldDraw", function(self)
+	return self:DoorOpen(true)
+end)
+
+ENT:AddHook("ShouldNotDrawProjectedLight","baseShouldntDraw",function(self)
+    if (not TARDIS:GetSetting("extprojlight-enabled")) or (not self.interior) then return true end
+    if self:GetData("vortex",false)==true then return true end
 end)
 
 ENT:AddHook("Think", "projectedlight", function(self)
-    if not self.interior then return end
-    if (self:CallHook("ShouldDrawProjectedLight")==false) then
+	if not self.interior then return end
+	local shouldon = self:CallHook("ShouldDrawProjectedLight")
+	local shouldoff = self:CallHook("ShouldNotDrawProjectedLight")
 
-        if self.projectedlight:GetEnableShadows() == true then 
-            self.projectedlight:SetEnableShadows(false)
-            self.projectedlight:SetBrightness(0)
-            self.projectedlight:Update()
+	if shouldon and (not shouldoff) then
+        if (not self.projectedlight) or (not IsValid(self.projectedlight)) then
+            self:CreateProjectedLight()
+        else
+            self:UpdateProjectedLight()
         end
-        return
+    elseif self.projectedlight then
+        self:RemoveProjectedLight()
     end
-    if self.projectedlight:GetBrightness() > 0 and not self:DoorOpen(true) then
-        self.projectedlight:SetEnableShadows(false)
-        self.projectedlight:SetBrightness(0)
-        self.projectedlight:Update()
-    elseif self:DoorOpen(true) and self.projectedlight:GetBrightness() == 0 then
-        self.projectedlight:SetEnableShadows(true)
-        self.projectedlight:SetBrightness(self.projlightsettings.calculatedbrightness)
-    end
-    if ( IsValid( self.projectedlight ) ) and self:DoorOpen(true) then
-		self.projectedlight:SetPos( self:LocalToWorld(Vector(-25,0,51.1)) )
-		self.projectedlight:SetAngles( self:LocalToWorldAngles(Angle(0,0,0)) )
-		self.projectedlight:Update()
-	end
 end)

--- a/lua/entities/gmod_tardis/modules/cl_projectedlight.lua
+++ b/lua/entities/gmod_tardis/modules/cl_projectedlight.lua
@@ -15,18 +15,19 @@ function ENT:CalcLightBrightness(pos)
 	local rm = 0.299*lightcolour.r
 	local gm = 0.587*lightcolour.g
 	local bm = 0.114*lightcolour.b
-	local luminance = rm + gm + rm
+	local luminance = rm + gm + bm
 	return luminance
 end
 
 function ENT:CreateProjectedLight()
 	if self.projectedlight then return end
-	local pl = ProjectedTexture()
+    local pl = ProjectedTexture()
+    self:SetData("pl-warning",self:GetData("health-warning"))
 	pl:SetTexture("effects/flashlight/square")
 	pl:SetFarZ(250)
 	pl:SetVerticalFOV(self.metadata.Exterior.Portal.height)
 	pl:SetHorizontalFOV(self.metadata.Exterior.Portal.width+10)
-	pl:SetColor(self.metadata.Interior.Light.color)
+	pl:SetColor(self:GetData("health-warning",false) and self.metadata.Interior.Light.warncolor or self.metadata.Interior.Light.color)
     pl:SetBrightness(0.5)
     pl:SetPos(self:LocalToWorld(Vector(-21,0,51.1)))
     pl:SetEnableShadows(true)
@@ -43,6 +44,15 @@ function ENT:RemoveProjectedLight()
 end
 
 function ENT:UpdateProjectedLight()
+    local warning = self:GetData("health-warning",false)
+    if warning~=self:GetData("pl-warning",false) then
+        self:SetData("pl-warning",warning)
+        if warning then
+            self.projectedlight:SetColor(self.metadata.Interior.Light.warncolor or self.metadata.Interior.Light.color)
+        else
+            self.projectedlight:SetColor(self.metadata.Interior.Light.color)
+        end
+    end
     self.projectedlight:SetPos(self:LocalToWorld(Vector(-21,0,51.1)))
     self.projectedlight:SetAngles(self:GetAngles())
     self.projectedlight:Update()

--- a/lua/entities/gmod_tardis/modules/cl_projectedlight.lua
+++ b/lua/entities/gmod_tardis/modules/cl_projectedlight.lua
@@ -10,8 +10,9 @@ TARDIS:AddSetting({
 	networked=true
 })
 
-function ENT:CalcLightBrightness()
-    local lightcolour = render.GetLightColor(self:GetPos()):ToColor()
+function ENT:CalcLightBrightness(interior)
+    local pos = (interior and self.interior:GetPos() or self:GetPos())
+    local lightcolour = render.GetLightColor(pos):ToColor()
     local rm = 0.299*lightcolour.r
     local gm = 0.587*lightcolour.g
     local bm = 0.114*lightcolour.b
@@ -20,6 +21,7 @@ function ENT:CalcLightBrightness()
 end
 
 ENT:AddHook("Initialize", "projectedlight", function(self)
+    if not self.interior then return end
     self.projlightsettings = {}
     self.projectedlight = ProjectedTexture()
     self.projectedlight:SetTexture("effects/flashlight/square")
@@ -30,7 +32,7 @@ ENT:AddHook("Initialize", "projectedlight", function(self)
     --self.projectedlight:SetBrightness(0.5)
 	self.projectedlight:SetPos(self:LocalToWorld(Vector(0,0,50)))
     self.projectedlight:SetAngles(self:GetAngles())
-    self.projlightsettings.basebrightness = 1
+    self.projlightsettings.basebrightness = 0.5
     self.projlightsettings.calculatedbrightness = self.projlightsettings.basebrightness
 	self.projectedlight:Update()
 end)
@@ -46,7 +48,9 @@ ENT:AddHook("ShouldDrawProjectedLight", "setting", function(self)
 end)
 
 ENT:AddHook("Think", "projectedlight", function(self)
+    if not self.interior then return end
     if (self:CallHook("ShouldDrawProjectedLight")==false) then
+
         if self.projectedlight:GetEnableShadows() == true then 
             self.projectedlight:SetEnableShadows(false)
             self.projectedlight:SetBrightness(0)

--- a/lua/entities/gmod_tardis/modules/sh_float.lua
+++ b/lua/entities/gmod_tardis/modules/sh_float.lua
@@ -100,7 +100,13 @@ if SERVER then
 		if self:GetData("float") then
 			self.phys:Wake()
 		end
-	end)
+    end)
+    
+    ENT:AddHook("OnHealthDepleted","float",function(self)
+        if self:GetData("float") then
+            self:SetFloat(false)
+        end
+    end)
 	
 	ENT:AddHook("PhysicsUpdate", "float", function(self,ph)
 		if self:GetData("float") then

--- a/lua/entities/gmod_tardis/modules/sh_float.lua
+++ b/lua/entities/gmod_tardis/modules/sh_float.lua
@@ -7,8 +7,9 @@ TARDIS:AddKeyBind("float-toggle",{
 	desc="Lets the TARDIS fly as if there is no gravity",
 	func=function(self,down,ply)
 		if ply==self.pilot and down then
-			self:ToggleFloat()
-			ply:ChatPrint("Float "..(self:GetData("floatfirst") and "en" or "dis").."abled")
+			if self:ToggleFloat() then
+				ply:ChatPrint("Float "..(self:GetData("floatfirst") and "en" or "dis").."abled")
+			end
 		end
 	end,
 	key=KEY_T,
@@ -71,8 +72,10 @@ TARDIS:AddKeyBind("float-brake",{
 if SERVER then
 	function ENT:SetFloat(on)
 		if (not on) and self:CallHook("CanTurnOffFloat")==false then return end
+		if (on) and self:CallHook("CanTurnOnFloat")==false then return end
 		self:SetData("float",on,true)
 		self.phys:EnableGravity(not on)
+		return true
 	end
 	
 	function ENT:ToggleFloat()
@@ -82,11 +85,15 @@ if SERVER then
 		else
 			self:SetData("floatfirst",on)
 		end
-		self:SetFloat(on)
+		return self:SetFloat(on)
 	end
 	
 	ENT:AddHook("CanTurnOffFloat", "float", function(self)
 		if self:GetData("floatfirst") then return false	end
+	end)
+
+	ENT:AddHook("CanTurnOnFloat", "float", function(self)
+		if not self:GetData("power-state") then return false end
 	end)
 	
 	ENT:AddHook("Think", "float", function(self)

--- a/lua/entities/gmod_tardis/modules/sh_health.lua
+++ b/lua/entities/gmod_tardis/modules/sh_health.lua
@@ -130,17 +130,19 @@ if SERVER then
             local creator = self:GetCreator()
             local ent = ents.Create("gmod_tardis")
             ent:SetCreator(creator)
-            ent:SetPos(pos)
+            ent:SetPos(pos+Vector(0,0,2))
             ent:SetAngles(ang)
             self:Remove()
 
             ent:Spawn()
+            ent:GetPhysicsObject():Sleep()
             undo.Create("TARDIS Rewrite")
                 undo.AddEntity(ent)
                 undo.SetPlayer(creator)
             undo.Finish()
-            timer.Simple(1.2, function()
+            timer.Simple(0.5, function()
                 if not IsValid(ent) then return end
+                ent:GetPhysicsObject():Wake()
                 ent:FinishRepair()
             end)
             return

--- a/lua/entities/gmod_tardis/modules/sh_health.lua
+++ b/lua/entities/gmod_tardis/modules/sh_health.lua
@@ -49,7 +49,7 @@ function ENT:ChangeHealth(newhealth)
         end
     end
     self:SetData("health-val", newhealth, true)
-    self:CallHook("OnHealthChange",newhealth, oldhealth)
+    self:CallHook("OnHealthChange", newhealth, oldhealth)
     self.interior:CallHook("OnHealthChange", newhealth, oldhealth)
 end
 
@@ -151,6 +151,7 @@ if SERVER then
         self:EmitSound(self.metadata.Exterior.Sounds.RepairFinish)
         self:SetData("repairing", false, true)
         self:ChangeHealth(TARDIS:GetSetting("health-max"))
+        self:CallHook("RepairFinished")
         self.interior:SetPower(true)
         self:SetLocked(false, nil, true)
         self:GetCreator():ChatPrint("Your TARDIS has finished self-repairing")
@@ -298,7 +299,6 @@ if SERVER then
     ENT:AddHook("OnHealthChange", "warning", function(self)
         if self:GetHealthPercent() <= 20 and (not self:GetData("health-warning",false)) then
             self:SetData("health-warning", true, true)
-            --self:StartCloisters()
             self:StartSmoke()
             if self.interior then
                 self.interior:StartCloisters()
@@ -309,7 +309,6 @@ if SERVER then
     ENT:AddHook("OnHealthChange", "warning-stop", function(self)
         if self:GetHealthPercent() > 20 and (self:GetData("health-warning",false)) then
             self:SetData("health-warning", false, true)
-            --self:StartCloisters()
             self:StopSmoke()
             if self.interior then
                 self.interior:StopCloisters()

--- a/lua/entities/gmod_tardis/modules/sh_health.lua
+++ b/lua/entities/gmod_tardis/modules/sh_health.lua
@@ -193,8 +193,8 @@ if SERVER then
     
     ENT:AddHook("CanRepair", "health", function(self)
         local intsetting = TARDIS:GetSetting("interior","default",self:GetCreator())
-        if TARDIS:GetInterior(intsetting) and (intsetting ~= self.metadata.ID) then return end
-        if (self:GetHealth() >= TARDIS:GetSetting("health-max",1)) or self:GetData("vortex",false) then return false end
+        if TARDIS:GetInterior(intsetting) and (intsetting ~= self.metadata.ID) and (not self:GetData("vortex",false))then return end
+        if (self:GetHealth() >= TARDIS:GetSetting("health-max",1)) then return false end
     end)
 
 	ENT:AddHook("CanTogglePower", "health", function(self)

--- a/lua/entities/gmod_tardis/modules/sh_health.lua
+++ b/lua/entities/gmod_tardis/modules/sh_health.lua
@@ -124,6 +124,27 @@ if SERVER then
     end
 
     function ENT:FinishRepair()
+        if TARDIS:GetSetting("interior","default",self:GetCreator()) ~= self.metadata.ID then
+            local pos = self:GetPos()
+            local ang = self:GetAngles()
+            local creator = self:GetCreator()
+            local ent = ents.Create("gmod_tardis")
+            ent:SetCreator(creator)
+            ent:SetPos(pos)
+            ent:SetAngles(ang)
+            self:Remove()
+
+            ent:Spawn()
+            undo.Create("TARDIS Rewrite")
+                undo.AddEntity(ent)
+                undo.SetPlayer(creator)
+            undo.Finish()
+            timer.Simple(1.2, function()
+                if not IsValid(ent) then return end
+                ent:FinishRepair()
+            end)
+            return
+        end
         self:EmitSound(self.metadata.Exterior.Sounds.RepairFinish)
         self:SetData("repairing", false, true)
         self:ChangeHealth(TARDIS:GetSetting("health-max"))

--- a/lua/entities/gmod_tardis/modules/sh_health.lua
+++ b/lua/entities/gmod_tardis/modules/sh_health.lua
@@ -49,7 +49,8 @@ function ENT:ChangeHealth(newhealth)
         end
     end
     self:SetData("health-val", newhealth, true)
-    self:CallHook("OnHealthChange")
+    self:CallHook("OnHealthChange",newhealth, oldhealth)
+    self.interior:CallHook("OnHealthChange", newhealth, oldhealth)
 end
 
 function ENT:GetHealth()

--- a/lua/entities/gmod_tardis/modules/sh_health.lua
+++ b/lua/entities/gmod_tardis/modules/sh_health.lua
@@ -97,7 +97,6 @@ if SERVER then
 			self:ChangeHealth(TARDIS:GetSetting("health-max"),1)
 			return 
 		end
-        if (self:GetHealth() >= TARDIS:GetSetting("health-max",1)) or self:GetData("vortex",false) then return end
         if self:CallHook("CanRepair")==false then return end
 		if on==true then
 			for k,_ in pairs(self.occupants) do

--- a/lua/entities/gmod_tardis/modules/sh_health.lua
+++ b/lua/entities/gmod_tardis/modules/sh_health.lua
@@ -44,12 +44,12 @@ function ENT:ChangeHealth(newhealth)
     if newhealth <= 0 then
         newhealth = 0
         if newhealth == 0 and not (newhealth == oldhealth) then
-            self:CallHook("health-depleted")
-            self.interior:CallHook("health-depleted")
+            self:CallHook("OnHealthDepleted")
+            self.interior:CallHook("OnHealthDepleted")
         end
     end
     self:SetData("health-val", newhealth, true)
-    self:CallHook("health-change")
+    self:CallHook("OnHealthChange")
 end
 
 function ENT:GetHealth()
@@ -273,14 +273,14 @@ if SERVER then
         self:ChangeHealth(newhealth)
     end)
 
-    ENT:AddHook("health-change", "FallbackNetwork", function(self)
+    ENT:AddHook("OnHealthChange", "FallbackNetwork", function(self)
         local health = self:GetData("health-val")
         self:SendMessage("health-networking", function()
             net.WriteInt(health, 32)
         end)
     end)
 
-    ENT:AddHook("health-depleted", "death", function(self)
+    ENT:AddHook("OnHealthDepleted", "death", function(self)
         self.interior:SetPower(false)
         if self:GetData("vortex",false) then
             self:Mat()
@@ -294,7 +294,7 @@ if SERVER then
         end)
     end)
 
-    ENT:AddHook("health-change", "warning", function(self)
+    ENT:AddHook("OnHealthChange", "warning", function(self)
         if self:GetHealthPercent() <= 20 and (not self:GetData("health-warning",false)) then
             self:SetData("health-warning", true, true)
             --self:StartCloisters()
@@ -305,7 +305,7 @@ if SERVER then
         end
     end)
 
-    ENT:AddHook("health-change", "warning-stop", function(self)
+    ENT:AddHook("OnHealthChange", "warning-stop", function(self)
         if self:GetHealthPercent() > 20 and (self:GetData("health-warning",false)) then
             self:SetData("health-warning", false, true)
             --self:StartCloisters()
@@ -326,7 +326,7 @@ else
         self:SetData("UpdateHealthScreen", true, true)
     end)
 
-    --[[ENT:AddHook("health-change", "cloisters", function(self)
+    --[[ENT:AddHook("OnHealthChange", "cloisters", function(self)
         if self:GetHealthPercent() < 20 and (not self:GetData("health-warning",false)) then
             self:SetData("health-warning", true, true)
             --self:StartCloisters()

--- a/lua/entities/gmod_tardis/modules/sh_health.lua
+++ b/lua/entities/gmod_tardis/modules/sh_health.lua
@@ -267,8 +267,9 @@ if SERVER then
         if self:GetHealthPercent() <= 20 and (not self:GetData("health-warning",false)) then
             self:SetData("health-warning", true, true)
             self:StartSmoke()
+            self:CallHook("HealthWarningToggled",true)
             if self.interior then
-                self.interior:StartCloisters()
+                self.interior:CallHook("HealthWarningToggled",true)
             end
         end
     end)
@@ -277,8 +278,9 @@ if SERVER then
         if self:GetHealthPercent() > 20 and (self:GetData("health-warning",false)) then
             self:SetData("health-warning", false, true)
             self:StopSmoke()
+            self:CallHook("HealthWarningToggled",false)
             if self.interior then
-                self.interior:StopCloisters()
+                self.interior:CallHook("HealthWarningToggled",false)
             end
         end
     end)

--- a/lua/entities/gmod_tardis/modules/sh_health.lua
+++ b/lua/entities/gmod_tardis/modules/sh_health.lua
@@ -5,293 +5,301 @@ CreateConVar("tardis2_damage", 1, {FCVAR_ARCHIVE, FCVAR_REPLICATED, FCVAR_NOTIFY
 
 
 TARDIS:AddSetting({
-    id="health-enabled",
-    name="Enable Health",
-    desc="Should the TARDIS have health and take damage?",
-    section="Health",
-    value=true,
-    type="bool",
-    setting=true,
-    networked=true
+	id="health-enabled",
+	name="Enable Health",
+	desc="Should the TARDIS have health and take damage?",
+	section="Health",
+	value=true,
+	type="bool",
+	setting=true,
+	networked=true
 })
 
 TARDIS:AddSetting({
-    id="health-max",
-    name="Max Health",
-    desc="Maximum ammount of health the TARDIS has",
-    section="Misc",
-    type="number",
-    value=1000,
-    min=1,
-    max=50000,
-    networked=true
+	id="health-max",
+	name="Max Health",
+	desc="Maximum ammount of health the TARDIS has",
+	section="Misc",
+	type="number",
+	value=1000,
+	min=1,
+	max=50000,
+	networked=true
 })
 
 ENT:AddHook("Initialize","health-init",function(self)
-    self:SetData("health-val", TARDIS:GetSetting("health-max"), true)
+	self:SetData("health-val", TARDIS:GetSetting("health-max"), true)
 end)
 
 function ENT:ChangeHealth(newhealth)
-    if self:GetData("repairing", false) then
-        return
-    end
-    local maxhealth = TARDIS:GetSetting("health-max")
-    local oldhealth = self:GetHealth()
-    if newhealth > oldhealth and oldhealth+newhealth > maxhealth then
-        newhealth = maxhealth
-    end
-    if newhealth <= 0 then
-        newhealth = 0
-        if newhealth == 0 and not (newhealth == oldhealth) then
-            self:CallHook("OnHealthDepleted")
-            self.interior:CallHook("OnHealthDepleted")
-        end
-    end
-    self:SetData("health-val", newhealth, true)
-    self:CallHook("OnHealthChange", newhealth, oldhealth)
-    self.interior:CallHook("OnHealthChange", newhealth, oldhealth)
+	if self:GetData("repairing", false) then
+		return
+	end
+	local maxhealth = TARDIS:GetSetting("health-max")
+	local oldhealth = self:GetHealth()
+	if newhealth > oldhealth and oldhealth+newhealth > maxhealth then
+		newhealth = maxhealth
+	end
+	if newhealth <= 0 then
+		newhealth = 0
+		if newhealth == 0 and not (newhealth == oldhealth) then
+			self:CallHook("OnHealthDepleted")
+			self.interior:CallHook("OnHealthDepleted")
+		end
+	end
+	self:SetData("health-val", newhealth, true)
+	self:CallHook("OnHealthChange", newhealth, oldhealth)
+	self.interior:CallHook("OnHealthChange", newhealth, oldhealth)
 end
 
 function ENT:GetHealth()
-    return self:GetData("health-val", 0)
+	return self:GetData("health-val", 0)
 end
 
 function ENT:GetHealthPercent()
-    local val = self:GetData("health-val", 0)
-    local percent = (val * 100)/TARDIS:GetSetting("health-max",1)
-    return percent
+	local val = self:GetData("health-val", 0)
+	local percent = (val * 100)/TARDIS:GetSetting("health-max",1)
+	return percent
 end
 
 function ENT:GetRepairTime()
-    return self:GetData("repair-time")-CurTime()
+	return self:GetData("repair-time")-CurTime()
 end
 
 if SERVER then
-    cvars.AddChangeCallback("tardis2_maxhealth", function(cvname, oldvalue, newvalue)
-        local nvnum = tonumber(newvalue)
-        if nvnum < 0 then
-            nvnum = 1
-        end
-       TARDIS:SetSetting("health-max", nvnum, true)
-    end, "UpdateOnChange")
+	cvars.AddChangeCallback("tardis2_maxhealth", function(cvname, oldvalue, newvalue)
+		local nvnum = tonumber(newvalue)
+		if nvnum < 0 then
+			nvnum = 1
+		end
+	   TARDIS:SetSetting("health-max", nvnum, true)
+	end, "UpdateOnChange")
 
-    cvars.AddChangeCallback("tardis2_damage", function(cvname, oldvalue, newvalue)
-       TARDIS:SetSetting("health-enabled", tobool(newvalue), true)
-    end, "UpdateOnChange")
+	cvars.AddChangeCallback("tardis2_damage", function(cvname, oldvalue, newvalue)
+	   TARDIS:SetSetting("health-enabled", tobool(newvalue), true)
+	end, "UpdateOnChange")
 
-    function ENT:Explode()
-        local explode = ents.Create("env_explosion")
-        explode:SetPos( self:LocalToWorld(Vector(0,0,50)) )
-        explode:SetOwner( self )
-        explode:Spawn()
-        explode:SetKeyValue("iMagnitude","60")
-        explode:Fire("Explode", 0, 0 )
+	function ENT:Explode()
+		local explode = ents.Create("env_explosion")
+		explode:SetPos( self:LocalToWorld(Vector(0,0,50)) )
+		explode:SetOwner( self )
+		explode:Spawn()
+		explode:SetKeyValue("iMagnitude","60")
+		explode:Fire("Explode", 0, 0 )
+	end
+
+	function ENT:ToggleRepair()
+		local on = not self:GetData("repair-primed",false)
+		self:SetRepair(on)
+	end
+	function ENT:SetRepair(on)
+		if not TARDIS:GetSetting("health-enabled") and self:GetHealth()~=TARDIS:GetSetting("health-max",1) then 
+			self:ChangeHealth(TARDIS:GetSetting("health-max"),1)
+			return 
+		end
+        if (self:GetHealth() >= TARDIS:GetSetting("health-max",1)) or self:GetData("vortex",false) then return end
+        if self:CallHook("CanRepair")==false then return end
+		if on==true then
+			for k,_ in pairs(self.occupants) do
+				k:ChatPrint("This TARDIS has been set to self-repair. Please vacate the interior.")
+			end
+			if self:GetData("power-state") then self:SetPower(false) end
+			self:SetData("repair-primed",true,true)
+		else
+			self:SetData("repair-primed",false,true)
+			self.interior:SetPower(true)
+			for k,_ in pairs(self.occupants) do
+				k:ChatPrint("TARDIS self-repair has been cancelled.")
+			end
+		end
+	end
+
+	function ENT:StartRepair()
+		if not IsValid(self) then return end
+		self:SetLocked(true)
+		local time = CurTime()+(math.Clamp((TARDIS:GetSetting("health-max")-self:GetData("health-val"))*0.1, 1, 60))
+		self:SetData("repair-time", time, true)
+		self:SetData("repairing", true, true)
+		self:SetData("repair-primed", false)
+		self:CallHook("RepairStarted")
+	end
+
+	function ENT:FinishRepair()
+		if TARDIS:GetSetting("interior","default",self:GetCreator()) ~= self.metadata.ID then
+			local pos = self:GetPos()
+			local ang = self:GetAngles()
+			local creator = self:GetCreator()
+			local ent = ents.Create("gmod_tardis")
+			ent:SetCreator(creator)
+			ent:SetPos(pos+Vector(0,0,2))
+			ent:SetAngles(ang)
+			self:Remove()
+
+			ent:Spawn()
+			ent:GetPhysicsObject():Sleep()
+			undo.Create("TARDIS Rewrite")
+				undo.AddEntity(ent)
+				undo.SetPlayer(creator)
+			undo.Finish()
+			timer.Simple(0.5, function()
+				if not IsValid(ent) then return end
+				ent:GetPhysicsObject():Wake()
+				ent:EmitSound(ent.metadata.Exterior.Sounds.RepairFinish)
+				ent:FlashLight(1.5)
+			end)
+			return
+		end
+		self:EmitSound(self.metadata.Exterior.Sounds.RepairFinish)
+		self:SetData("repairing", false, true)
+		self:ChangeHealth(TARDIS:GetSetting("health-max"))
+		self:CallHook("RepairFinished")
+		self.interior:SetPower(true)
+		self:SetLocked(false, nil, true)
+		self:GetCreator():ChatPrint("Your TARDIS has finished self-repairing")
+		self:StopSmoke()
+		self:FlashLight(1.5)
+	end
+
+	function ENT:StartSmoke()
+		local smoke = ents.Create("env_smokestack")
+		smoke:SetPos(self:LocalToWorld(Vector(0,0,80)))
+		smoke:SetAngles(self:GetAngles()+Angle(-90,0,0))
+		smoke:SetKeyValue("InitialState", "1")
+		smoke:SetKeyValue("WindAngle", "0 0 0")
+		smoke:SetKeyValue("WindSpeed", "0")
+		smoke:SetKeyValue("rendercolor", "50 50 50")
+		smoke:SetKeyValue("renderamt", "170")
+		smoke:SetKeyValue("SmokeMaterial", "particle/smokesprites_0001.vmt")
+		smoke:SetKeyValue("BaseSpread", "5")
+		smoke:SetKeyValue("SpreadSpeed", "10")
+		smoke:SetKeyValue("Speed", "50")
+		smoke:SetKeyValue("StartSize", "30")
+		smoke:SetKeyValue("EndSize", "70")
+		smoke:SetKeyValue("roll", "20")
+		smoke:SetKeyValue("Rate", "10")
+		smoke:SetKeyValue("JetLength", "100")
+		smoke:SetKeyValue("twist", "5")
+		smoke:Spawn()
+		smoke:SetParent(self)
+		smoke:Activate()
+		self.smoke=smoke
+	end
+
+	function ENT:StopSmoke()
+		if self.smoke and IsValid(self.smoke) then
+			self.smoke:Remove()
+			self.smoke=nil
+		end
     end
-
-    function ENT:ToggleRepair()
-        local on = not self:GetData("repair-primed",false)
-        self:SetRepair(on)
-    end
-    function ENT:SetRepair(on)
-        if not TARDIS:GetSetting("health-enabled") and self:GetHealth()~=TARDIS:GetSetting("health-max",1) then 
-            self:ChangeHealth(TARDIS:GetSetting("health-max"),1)
-            return 
-        end
-        if (self:GetHealth() > TARDIS:GetSetting("health-max",1)-1) or self:GetData("vortex",false) then return end
-        if on==true then
-            for k,_ in pairs(self.occupants) do
-                k:ChatPrint("This TARDIS has been set to self-repair. Please vacate the interior.")
-            end
-            if self:GetData("power-state") then self:SetPower(false) end
-            self:SetData("repair-primed",true,true)
-        else
-            self:SetData("repair-primed",false,true)
-            self.interior:SetPower(true)
-            for k,_ in pairs(self.occupants) do
-                k:ChatPrint("TARDIS self-repair has been cancelled.")
-            end
-        end
-    end
-
-    function ENT:StartRepair()
-        if not IsValid(self) then return end
-        self:SetLocked(true)
-        local time = CurTime()+(math.Clamp((TARDIS:GetSetting("health-max")-self:GetData("health-val"))*0.1, 1, 60))
-        self:SetData("repair-time", time, true)
-        self:SetData("repairing", true, true)
-        self:SetData("repair-primed", false)
-        self:CallHook("RepairStarted")
-    end
-
-    function ENT:FinishRepair()
-        if TARDIS:GetSetting("interior","default",self:GetCreator()) ~= self.metadata.ID then
-            local pos = self:GetPos()
-            local ang = self:GetAngles()
-            local creator = self:GetCreator()
-            local ent = ents.Create("gmod_tardis")
-            ent:SetCreator(creator)
-            ent:SetPos(pos+Vector(0,0,2))
-            ent:SetAngles(ang)
-            self:Remove()
-
-            ent:Spawn()
-            ent:GetPhysicsObject():Sleep()
-            undo.Create("TARDIS Rewrite")
-                undo.AddEntity(ent)
-                undo.SetPlayer(creator)
-            undo.Finish()
-            timer.Simple(0.5, function()
-                if not IsValid(ent) then return end
-                ent:GetPhysicsObject():Wake()
-                ent:FinishRepair()
-            end)
-            return
-        end
-        self:EmitSound(self.metadata.Exterior.Sounds.RepairFinish)
-        self:SetData("repairing", false, true)
-        self:ChangeHealth(TARDIS:GetSetting("health-max"))
-        self:CallHook("RepairFinished")
-        self.interior:SetPower(true)
-        self:SetLocked(false, nil, true)
-        self:GetCreator():ChatPrint("Your TARDIS has finished self-repairing")
-        self:StopSmoke()
-        self:FlashLight(1.5)
-    end
-
-    function ENT:StartSmoke()
-        local smoke = ents.Create("env_smokestack")
-        smoke:SetPos(self:LocalToWorld(Vector(0,0,80)))
-        smoke:SetAngles(self:GetAngles()+Angle(-90,0,0))
-        smoke:SetKeyValue("InitialState", "1")
-        smoke:SetKeyValue("WindAngle", "0 0 0")
-        smoke:SetKeyValue("WindSpeed", "0")
-        smoke:SetKeyValue("rendercolor", "50 50 50")
-        smoke:SetKeyValue("renderamt", "170")
-        smoke:SetKeyValue("SmokeMaterial", "particle/smokesprites_0001.vmt")
-        smoke:SetKeyValue("BaseSpread", "5")
-        smoke:SetKeyValue("SpreadSpeed", "10")
-        smoke:SetKeyValue("Speed", "50")
-        smoke:SetKeyValue("StartSize", "30")
-        smoke:SetKeyValue("EndSize", "70")
-        smoke:SetKeyValue("roll", "20")
-        smoke:SetKeyValue("Rate", "10")
-        smoke:SetKeyValue("JetLength", "100")
-        smoke:SetKeyValue("twist", "5")
-        smoke:Spawn()
-        smoke:SetParent(self)
-        smoke:Activate()
-        self.smoke=smoke
-    end
-
-    function ENT:StopSmoke()
-        if self.smoke and IsValid(self.smoke) then
-            self.smoke:Remove()
-            self.smoke=nil
-        end
-    end
-
-    ENT:AddHook("CanTogglePower", "health", function(self)
-        if (not (self:GetData("health-val", 0) > 0)) or (self:GetData("repairing",false) or self:GetData("repair-primed", false)) then
-            return false
-        end
+    
+    ENT:AddHook("CanRepair", "health", function(self)
+        local intsetting = TARDIS:GetSetting("interior","default",self:GetCreator())
+        if TARDIS:GetInterior(intsetting) and (intsetting ~= self.metadata.ID) then return end
+        if (self:GetHealth() >= TARDIS:GetSetting("health-max",1)) or self:GetData("vortex",false) then return false end
     end)
 
-    ENT:AddHook("CanLock", "repair", function(self)
-        if (not self:GetData("repairing",false)) then return true end
-    end)
+	ENT:AddHook("CanTogglePower", "health", function(self)
+		if (not (self:GetData("health-val", 0) > 0)) or (self:GetData("repairing",false) or self:GetData("repair-primed", false)) then
+			return false
+		end
+	end)
 
-    ENT:AddHook("PostPlayerExit", "repair", function(self,ply,forced,notp)
-        if (self:GetData("repair-primed",false)==true) and (table.IsEmpty(self.occupants)) then
-            self:SetData("repair-shouldstart", true)
-            self:SetData("repair-delay", CurTime()+0.3)
-        end
-    end)
+	ENT:AddHook("CanLock", "repair", function(self)
+		if (not self:GetData("repairing",false)) then return true end
+	end)
 
-    ENT:AddHook("PlayerEnter", "repair", function(self,ply,forced,notp)
-        if (self:GetData("repair-primed",false)==true) and table.Count(self.occupants)>=0 then
-            self:SetData("repair-shouldstart", false)
-        end
-    end)
+	ENT:AddHook("PostPlayerExit", "repair", function(self,ply,forced,notp)
+		if (self:GetData("repair-primed",false)==true) and (table.IsEmpty(self.occupants)) then
+			self:SetData("repair-shouldstart", true)
+			self:SetData("repair-delay", CurTime()+0.3)
+		end
+	end)
 
-    ENT:AddHook("LockedUse", "repair", function(self, a)
-        if self:GetData("repairing") then
-            a:ChatPrint("This TARDIS is repairing. It will be done in "..math.floor(self:GetRepairTime()).." seconds.")
-            return true
-        end
-    end)
+	ENT:AddHook("PlayerEnter", "repair", function(self,ply,forced,notp)
+		if (self:GetData("repair-primed",false)==true) and table.Count(self.occupants)>=0 then
+			self:SetData("repair-shouldstart", false)
+		end
+	end)
 
-    ENT:AddHook("Think", "repair", function(self)
-        if self:GetData("repair-primed",false) and self:GetData("repair-shouldstart") and CurTime() > self:GetData("repair-delay") then
-            self:SetData("repair-shouldstart", false)
-            self:StartRepair()
-        end
+	ENT:AddHook("LockedUse", "repair", function(self, a)
+		if self:GetData("repairing") then
+			a:ChatPrint("This TARDIS is repairing. It will be done in "..math.floor(self:GetRepairTime()).." seconds.")
+			return true
+		end
+	end)
 
-        if (self:GetData("repairing",false) and CurTime()>self:GetData("repair-time",0)) then
-            self:FinishRepair()
-        end
-    end)
+	ENT:AddHook("Think", "repair", function(self)
+		if self:GetData("repair-primed",false) and self:GetData("repair-shouldstart") and CurTime() > self:GetData("repair-delay") then
+			self:SetData("repair-shouldstart", false)
+			self:StartRepair()
+		end
 
-    ENT:AddHook("ShouldTakeDamage", "DamageOff", function(self, dmginfo)
-        if not TARDIS:GetSetting("health-enabled") then return false end
-    end)
+		if (self:GetData("repairing",false) and CurTime()>self:GetData("repair-time",0)) then
+			self:FinishRepair()
+		end
+	end)
 
-    ENT:AddHook("OnTakeDamage", "Health", function(self, dmginfo)
-        if dmginfo:GetInflictor():GetClass() == "env_fire" then return end
-        local newhealth = self:GetHealth() - (dmginfo:GetDamage()/2)
-        self:ChangeHealth(newhealth)
-    end)
+	ENT:AddHook("ShouldTakeDamage", "DamageOff", function(self, dmginfo)
+		if not TARDIS:GetSetting("health-enabled") then return false end
+	end)
 
-    ENT:AddHook("PhysicsCollide", "Health", function(self, data, collider)
-        if not TARDIS:GetSetting("health-enabled") then return end
-        if (data.Speed < 300) then return end
-        local newhealth = self:GetHealth() - data.Speed / 23
-        self:ChangeHealth(newhealth)
-    end)
+	ENT:AddHook("OnTakeDamage", "Health", function(self, dmginfo)
+		if dmginfo:GetInflictor():GetClass() == "env_fire" then return end
+		local newhealth = self:GetHealth() - (dmginfo:GetDamage()/2)
+		self:ChangeHealth(newhealth)
+	end)
 
-    ENT:AddHook("OnHealthChange", "FallbackNetwork", function(self)
-        local health = self:GetData("health-val")
-        self:SendMessage("health-networking", function()
-            net.WriteInt(health, 32)
-        end)
-    end)
+	ENT:AddHook("PhysicsCollide", "Health", function(self, data, collider)
+		if not TARDIS:GetSetting("health-enabled") then return end
+		if (data.Speed < 300) then return end
+		local newhealth = self:GetHealth() - data.Speed / 23
+		self:ChangeHealth(newhealth)
+	end)
 
-    ENT:AddHook("OnHealthDepleted", "death", function(self)
-        self.interior:SetPower(false)
-        if self:GetData("vortex",false) then
-            self:Mat()
-        end
-        self:Explode()
-    end)
+	ENT:AddHook("OnHealthChange", "FallbackNetwork", function(self)
+		local health = self:GetData("health-val")
+		self:SendMessage("health-networking", function()
+			net.WriteInt(health, 32)
+		end)
+	end)
 
-    ENT:AddHook("OnHealthChange", "warning", function(self)
-        if self:GetHealthPercent() <= 20 and (not self:GetData("health-warning",false)) then
-            self:SetData("health-warning", true, true)
-            self:StartSmoke()
-            self:CallHook("HealthWarningToggled",true)
-            if self.interior then
-                self.interior:CallHook("HealthWarningToggled",true)
-            end
-        end
-    end)
+	ENT:AddHook("OnHealthDepleted", "death", function(self)
+		self.interior:SetPower(false)
+		if self:GetData("vortex",false) then
+			self:Mat()
+		end
+		self:Explode()
+	end)
 
-    ENT:AddHook("OnHealthChange", "warning-stop", function(self)
-        if self:GetHealthPercent() > 20 and (self:GetData("health-warning",false)) then
-            self:SetData("health-warning", false, true)
-            self:StopSmoke()
-            self:CallHook("HealthWarningToggled",false)
-            if self.interior then
-                self.interior:CallHook("HealthWarningToggled",false)
-            end
-        end
-    end)
+	ENT:AddHook("OnHealthChange", "warning", function(self)
+		if self:GetHealthPercent() <= 20 and (not self:GetData("health-warning",false)) then
+			self:SetData("health-warning", true, true)
+			self:StartSmoke()
+			self:CallHook("HealthWarningToggled",true)
+			if self.interior then
+				self.interior:CallHook("HealthWarningToggled",true)
+			end
+		end
+	end)
+
+	ENT:AddHook("OnHealthChange", "warning-stop", function(self)
+		if self:GetHealthPercent() > 20 and (self:GetData("health-warning",false)) then
+			self:SetData("health-warning", false, true)
+			self:StopSmoke()
+			self:CallHook("HealthWarningToggled",false)
+			if self.interior then
+				self.interior:CallHook("HealthWarningToggled",false)
+			end
+		end
+	end)
 else
-    ENT:AddHook("Initialize", "health-client", function(self)
-        
-    end)
+	ENT:AddHook("Initialize", "health-client", function(self)
+		
+	end)
 
-    ENT:OnMessage("health-networking", function(self, ply)
-        local newhealth = net.ReadInt(32)
-        self:ChangeHealth(newhealth)
-        self:SetData("UpdateHealthScreen", true, true)
-    end)
+	ENT:OnMessage("health-networking", function(self, ply)
+		local newhealth = net.ReadInt(32)
+		self:ChangeHealth(newhealth)
+		self:SetData("UpdateHealthScreen", true, true)
+	end)
 end

--- a/lua/entities/gmod_tardis/modules/sh_outside.lua
+++ b/lua/entities/gmod_tardis/modules/sh_outside.lua
@@ -4,7 +4,7 @@ if SERVER then
 	function ENT:SetOutsideView(ply, enabled)
 		if IsValid(ply) and ply:IsPlayer() and self.occupants[ply] and CurTime()>ply:GetTardisData("outsidecool", 0) then
 			if enabled then
-				if IsValid(ply:GetActiveWeapon()) then
+				if IsValid(ply:GetActiveWeapon()) and (ply:GetActiveWeapon():GetClass()~="tardis_hands") then
 					ply:SetTardisData("activewep", ply:GetActiveWeapon():GetClass())
 				end
 				ply:Give("tardis_hands")

--- a/lua/entities/gmod_tardis/modules/sh_power.lua
+++ b/lua/entities/gmod_tardis/modules/sh_power.lua
@@ -22,7 +22,7 @@ if SERVER then
         if not self:GetData("power-state",false) then return false end
     end)
 else
-    ENT:AddHook("ShouldDrawProjectedLight", "power", function(self)
-        if not self:GetData("power-state") then return false end
+    ENT:AddHook("ShouldNotDrawProjectedLight", "power", function(self)
+        if not self:GetData("power-state") then return true end
     end)
 end

--- a/lua/entities/gmod_tardis/modules/sh_power.lua
+++ b/lua/entities/gmod_tardis/modules/sh_power.lua
@@ -21,4 +21,8 @@ if SERVER then
     ENT:AddHook("CanTriggerHads","power",function(self)
         if not self:GetData("power-state",false) then return false end
     end)
+else
+    ENT:AddHook("ShouldDrawProjectedLight", "power", function(self)
+        if not self:GetData("power-state") then return false end
+    end)
 end

--- a/lua/entities/gmod_tardis/modules/sh_teleport.lua
+++ b/lua/entities/gmod_tardis/modules/sh_teleport.lua
@@ -402,21 +402,21 @@ else
 	ENT:OnMessage("mat", function(self)
 		self:SetData("mat",true)
 		self:SetData("step",1)
-		self:SetData("vortex",false)
+        self:SetData("vortex",false)
 	end)
 	
 	function ENT:StopDemat()
 		self:SetData("demat",false)
 		self:SetData("step",1)
 		self:SetData("vortex",true)
-		self:SetData("teleport",false)
+        self:SetData("teleport",false)
 		self:CallHook("StopDemat")
 	end
 	
 	function ENT:StopMat()
 		self:SetData("mat",false)
 		self:SetData("step",1)
-		self:SetData("teleport",false)
+        self:SetData("teleport",false)
 	end
 	
 	hook.Add("PostDrawTranslucentRenderables", "tardis-trace", function()
@@ -482,7 +482,7 @@ ENT:AddHook("Think","teleport",function(self,delta)
 		end
 		target=self:GetTargetAlpha()
 		self:SetData("alphatarget",target)
-	end
+    end
 	local sequencespeed = (self:GetData("demat-fast",false) and self.metadata.Exterior.Teleport.SequenceSpeedFast or self.metadata.Exterior.Teleport.SequenceSpeed)
 	alpha=math.Approach(alpha,target,delta*66*sequencespeed)
 	self:SetData("alpha",alpha)

--- a/lua/entities/gmod_tardis/modules/sh_teleport.lua
+++ b/lua/entities/gmod_tardis/modules/sh_teleport.lua
@@ -105,7 +105,7 @@ if SERVER then
 				else
 					self:SendMessage("premat",function() net.WriteVector(self:GetData("demat-pos",Vector())) end)
 					self:SetData("teleport",true)
-					local timerdelay = (self:GetData("demat-fast",false) and 1.8 or 8.5)
+					local timerdelay = (self:GetData("demat-fast",false) and 1.9 or 8.5)
 					timer.Simple(timerdelay,function()
 						if not IsValid(self) then return end
 						self:SendMessage("mat")
@@ -215,11 +215,11 @@ if SERVER then
 			end
 		end
 		self:CallHook("StopDemat")
-	end
+    end
 
 	ENT:AddHook("StopDemat", "teleport-fast", function(self)
 		if self:GetData("demat-fast",false) then
-			timer.Simple(0.1, function()
+			timer.Simple(0.3, function()
 				if not IsValid(self) then return end
 				self:Mat()
 			end)
@@ -384,7 +384,7 @@ else
 		end
 	end)
 	
-	ENT:OnMessage("premat", function(self)
+    ENT:OnMessage("premat", function(self)
 		self:SetData("teleport",true)
 		if TARDIS:GetSetting("teleport-sound") and TARDIS:GetSetting("sound") then
 			local ext = self.metadata.Exterior.Sounds.Teleport
@@ -405,7 +405,7 @@ else
         self:SetData("vortex",false)
 	end)
 	
-	function ENT:StopDemat()
+    function ENT:StopDemat()
 		self:SetData("demat",false)
 		self:SetData("step",1)
 		self:SetData("vortex",true)
@@ -413,7 +413,7 @@ else
 		self:CallHook("StopDemat")
 	end
 	
-	function ENT:StopMat()
+    function ENT:StopMat()
 		self:SetData("mat",false)
 		self:SetData("step",1)
         self:SetData("teleport",false)
@@ -467,7 +467,7 @@ ENT:AddHook("Think","teleport",function(self,delta)
 	if alpha==target then
 		if demat then
 			if step>=#self.metadata.Exterior.Teleport.DematSequence then
-				self:StopDemat()
+                self:StopDemat()
 				return
 			else
 				self:SetData("step",step+1)

--- a/lua/entities/gmod_tardis/modules/sv_hads.lua
+++ b/lua/entities/gmod_tardis/modules/sv_hads.lua
@@ -14,6 +14,7 @@ ENT:AddHook("OnTakeDamage", "hads", function(self)
 	if (self:GetData("hads",false)==true and self:GetData("hads-triggered",false)==false) and (not self:GetData("teleport",false)) then
 		self:GetCreator():ChatPrint("Your TARDIS is under attack and the HADS has been triggered!")
 		self:SetData("hads-triggered",true,true)
+		self:SetFastRemat(false)
 		self:Demat()
 		self:CallHook("HADSTrigger")
 	end

--- a/lua/entities/gmod_tardis/shared.lua
+++ b/lua/entities/gmod_tardis/shared.lua
@@ -26,6 +26,18 @@ function ENT:RemoveHook(name,id)
 	end
 end
 
+function ENT:GetHooksTable()
+    return hooks
+end
+
+function ENT:ListHooks(listInteriorHooks)
+    print("[Exterior]"..(SERVER and "[Server]" or "[Client]"))
+    for h in pairs(hooks) do
+        print(h)
+    end
+    if listInteriorHooks then self.interior:ListHooks() end
+end
+
 function ENT:CallHook(name,...)
 	local a,b,c,d,e,f
 	a,b,c,d,e,f=self.BaseClass.CallHook(self,name,...)

--- a/lua/entities/gmod_tardis_interior/modules/cl_flight.lua
+++ b/lua/entities/gmod_tardis_interior/modules/cl_flight.lua
@@ -24,7 +24,7 @@ ENT:AddHook("Think", "flight", function(self)
 			self.flightsound:ChangePitch(95+p,0.1)
 			self.flightsound:ChangeVolume(0.4)
 		else
-			self.flightsound=CreateSound(self, self.metadata.Exterior.Sounds.FlightLoop)	
+			self.flightsound=CreateSound(self, self.metadata.Interior.Sounds.FlightLoop or self.metadata.Exterior.Sounds.FlightLoop)	
 			self.flightsound:Play()
 		end
 	elseif self.flightsound then

--- a/lua/entities/gmod_tardis_interior/modules/cl_idlesound.lua
+++ b/lua/entities/gmod_tardis_interior/modules/cl_idlesound.lua
@@ -3,7 +3,8 @@
 TARDIS:AddSetting({
 	id="idlesounds",
 	name="Idle Sounds",
-	desc="Whether the idle sounds can be heard on the inside or not",
+    desc="Whether the idle sounds can be heard on the inside or not",
+    section="Sound",
 	value=true,
 	type="bool",
 	option=true

--- a/lua/entities/gmod_tardis_interior/modules/cl_lights.lua
+++ b/lua/entities/gmod_tardis_interior/modules/cl_lights.lua
@@ -1,21 +1,5 @@
 -- Lights
 
---[[
-ENT:AddHook("PreDraw", "lights", function(self)
-	render.SuppressEngineLighting(true)
-	render.SetLocalModelLights({
-		{
-			pos=self:LocalToWorld(Vector(0,0,200)),
-			color=Vector(0,3,8)
-		},
-		{
-			pos=self:LocalToWorld(Vector(0,0,100)),
-			color=Vector(0,5,5)
-		}
-	})
-end)
-]]--
-
 function ENT:DrawLight(id,light)
 	if self:CallHook("ShouldDrawLight",id,light)==false then return end
 	local dlight = DynamicLight(id)
@@ -82,8 +66,9 @@ ENT:AddHook("Draw", "lights-roundthings", function(self)
 end)
 
 ENT:AddHook("ShouldDrawLight", "lights", function(self,id,light)
-	if not self.exterior:GetData("power-state",false) then
-		if not IsValid(light) then return false end
+    local power = self.exterior:GetData("power-state",false)
+	if not power then
+        -- if not IsValid(light) then return power end
 		return light.nopower or false
 	end
 end)

--- a/lua/entities/gmod_tardis_interior/modules/cl_lights.lua
+++ b/lua/entities/gmod_tardis_interior/modules/cl_lights.lua
@@ -83,6 +83,7 @@ end)
 
 ENT:AddHook("ShouldDrawLight", "lights", function(self,id,light)
 	if not self.exterior:GetData("power-state",false) then
+		if not IsValid(light) then return false end
 		return light.nopower or false
 	end
 end)

--- a/lua/entities/gmod_tardis_interior/modules/cl_lights.lua
+++ b/lua/entities/gmod_tardis_interior/modules/cl_lights.lua
@@ -67,7 +67,7 @@ end)
 
 ENT:AddHook("ShouldDrawLight", "lights", function(self,id,light)
     local power = self.exterior:GetData("power-state",false)
-	if not power then
+	if power~=true then
         if light==nil then return false end
 		return light.nopower or false
 	end

--- a/lua/entities/gmod_tardis_interior/modules/cl_lights.lua
+++ b/lua/entities/gmod_tardis_interior/modules/cl_lights.lua
@@ -68,7 +68,7 @@ end)
 ENT:AddHook("ShouldDrawLight", "lights", function(self,id,light)
     local power = self.exterior:GetData("power-state",false)
 	if not power then
-        -- if not IsValid(light) then return power end
+        if light==nil then return false end
 		return light.nopower or false
 	end
 end)

--- a/lua/entities/gmod_tardis_interior/modules/cl_lights.lua
+++ b/lua/entities/gmod_tardis_interior/modules/cl_lights.lua
@@ -22,10 +22,12 @@ function ENT:DrawLight(id,light)
 	if ( dlight ) then
 		local size=1024
 		local c=light.color
+		local warnc = light.warncolor or c
+		local warning = self.exterior:GetData("health-warning", false)
 		dlight.Pos = self:LocalToWorld(light.pos)
-		dlight.r = c.r
-		dlight.g = c.g
-		dlight.b = c.b
+		dlight.r = (warning) and warnc.r or c.r
+		dlight.g = (warning) and warnc.g or c.g
+		dlight.b = (warning) and warnc.b or c.b
 		dlight.Brightness = light.brightness
 		dlight.Decay = size * 5
 		dlight.Size = size
@@ -81,6 +83,6 @@ end)
 
 ENT:AddHook("ShouldDrawLight", "lights", function(self,id,light)
 	if not self.exterior:GetData("power-state",false) then
-		return false
+		return light.nopower or false
 	end
 end)

--- a/lua/entities/gmod_tardis_interior/modules/cl_render.lua
+++ b/lua/entities/gmod_tardis_interior/modules/cl_render.lua
@@ -8,26 +8,22 @@ TARDIS:AddSetting({
     value=false,
     type="bool",
     option=true,
-    networked=true
 })
 
 local function predraw_o(self)
     if not TARDIS:GetSetting("lightoverride-enabled",false,LocalPlayer()) then return end
     if self.metadata.Interior.Light == nil then return end --because for some reason SOMEONE OUT THERE didn't define a light.
-    render.SuppressEngineLighting(true)
     --render.SetLightingMode(1)
     local light=self.metadata.Interior.Light
     local lights=self.metadata.Interior.Lights
     local warning = self.exterior:GetData("health-warning", false)
-    render.ResetModelLighting(0.3, 0.3, 0.3)
-
+    
+    render.SuppressEngineLighting(true)
     local tab={}
-    if self:CallHook("ShouldDrawLight",nil,light)==false then
-        --print("lights off")
-        render.SetLocalModelLights()
-        render.ResetModelLighting(0.05, 0.05, 0.05)
-    else
-        --print("lights on")
+
+    if self:CallHook("ShouldDrawLight",nil,light)~=false then
+        render.ResetModelLighting(0.3, 0.3, 0.3)
+
         local c=light.color
         local warnc = light.warncolor or c
         local lcolor = (warning) and warnc:ToVector() or c:ToVector()
@@ -37,11 +33,19 @@ local function predraw_o(self)
             pos = self:LocalToWorld(light.pos),
             quadraticFalloff=20,
         })
+    else
+        table.insert(tab,{
+            type=MATERIAL_LIGHT_POINT,
+            color=Vector(0,0,0),
+            pos = self:LocalToWorld(light.pos),
+            quadraticFalloff=1,
+        })
+        render.ResetModelLighting(0.05, 0.05, 0.05)
     end
     if lights then
-       -- print("i have lights")
         for _,l in pairs(lights) do
-            if self:CallHook("ShouldDrawLight",nil,l)==false then return end
+            local shouldDraw = self:CallHook("ShouldDrawLight",nil,l)
+            if shouldDraw==false then return end
             local c=l.color
             local warnc = l.warncolor or c
             local lcolor = (warning) and warnc:ToVector() or c:ToVector()
@@ -51,12 +55,9 @@ local function predraw_o(self)
                 pos = self:LocalToWorld(l.pos),
                 quadraticFalloff=10,
             }
-            --print("inserting lights")
             table.insert(tab, tab2)
         end
     end
-    --print("final lights table follows")
-    --PrintTable(tab)
     render.SetLocalModelLights(tab)
 end
 

--- a/lua/entities/gmod_tardis_interior/modules/cl_render.lua
+++ b/lua/entities/gmod_tardis_interior/modules/cl_render.lua
@@ -16,18 +16,21 @@ local function predraw_o(self)
     if self.metadata.Interior.Light == nil then return end --because for some reason SOMEONE OUT THERE didn't define a light.
     render.SuppressEngineLighting(true)
     --render.SetLightingMode(1)
-    render.ResetModelLighting(0.3, 0.3, 0.3)
     local light=self.metadata.Interior.Light
     local lights=self.metadata.Interior.Lights
     local warning = self.exterior:GetData("health-warning", false)
-    local c=light.color
-    local warnc = light.warncolor or c
-    local lcolor = (warning) and warnc:ToVector() or c:ToVector()
+    render.ResetModelLighting(0.3, 0.3, 0.3)
+
     local tab={}
-    if self:CallHook("ShouldDrawLight",nil,light)==false then 
-        render.ResetModelLighting(0.05, 0.05, 0.05)
+    if self:CallHook("ShouldDrawLight",nil,light)==false then
+        --print("lights off")
         render.SetLocalModelLights()
+        render.ResetModelLighting(0.05, 0.05, 0.05)
     else
+        --print("lights on")
+        local c=light.color
+        local warnc = light.warncolor or c
+        local lcolor = (warning) and warnc:ToVector() or c:ToVector()
         table.insert(tab,{
             type=MATERIAL_LIGHT_POINT,
             color=lcolor*light.brightness,
@@ -36,20 +39,24 @@ local function predraw_o(self)
         })
     end
     if lights then
-        for _,light in pairs(lights) do
-            if self:CallHook("ShouldDrawLight",nil,light)==false then return end
-            local c=light.color
-            local warnc = light.warncolor or c
+       -- print("i have lights")
+        for _,l in pairs(lights) do
+            if self:CallHook("ShouldDrawLight",nil,l)==false then return end
+            local c=l.color
+            local warnc = l.warncolor or c
             local lcolor = (warning) and warnc:ToVector() or c:ToVector()
             local tab2 = {
                 type=MATERIAL_LIGHT_POINT,
-                color=lcolor*light.brightness,
-                pos = self:LocalToWorld(light.pos),
+                color=lcolor*l.brightness,
+                pos = self:LocalToWorld(l.pos),
                 quadraticFalloff=10,
             }
+            --print("inserting lights")
             table.insert(tab, tab2)
         end
     end
+    --print("final lights table follows")
+    --PrintTable(tab)
     render.SetLocalModelLights(tab)
 end
 

--- a/lua/entities/gmod_tardis_interior/modules/cl_render.lua
+++ b/lua/entities/gmod_tardis_interior/modules/cl_render.lua
@@ -1,0 +1,59 @@
+-- Rendering override
+
+TARDIS:AddSetting({
+    id="lightoverride-enabled",
+    name="[Experimental]\nLighting Override",
+    desc="Enable/Disable experimental interior lighting.\nMay cause unexpected issues, and performance drops on lower end systems.",
+    section="Misc",
+    value=false,
+    type="bool",
+    option=true,
+    networked=true
+})
+
+local function predraw_o(self)
+    if not TARDIS:GetSetting("lightoverride-enabled",false,LocalPlayer()) then return end
+    render.SuppressEngineLighting(true)
+    --render.SetLightingMode(1)
+
+    render.ResetModelLighting(0.5, 0.5, 0.5)
+    local light=self.metadata.Interior.Light
+    local lights=self.metadata.Interior.Lights
+    local c = light.color:ToVector()
+    if self:CallHook("ShouldDrawLight") == false then 
+        render.ResetModelLighting(0.05, 0.05, 0.05)
+        render.SetLocalModelLights()
+        return 
+    end
+    --render.SetModelLighting(BOX_TOP, 1, 2, 3)
+    local tab={{
+        type=MATERIAL_LIGHT_POINT,
+        color=light.color:ToVector()*light.brightness,
+        pos = self:LocalToWorld(light.pos),
+        quadraticFalloff=20,
+    }}
+    if lights then
+        for _,light in pairs(lights) do
+            local tab2 = {
+                type=MATERIAL_LIGHT_POINT,
+                color=light.color:ToVector()*light.brightness,
+                pos = self:LocalToWorld(light.pos),
+                quadraticFalloff=10,
+            }
+            table.insert(tab, tab2)
+        end
+    end
+    render.SetLocalModelLights(tab)
+end
+
+local function postdraw_o(self)
+    render.SuppressEngineLighting(false)
+end
+
+ENT:AddHook("PreDraw", "customlighting", predraw_o)
+
+ENT:AddHook("Draw", "customlighting", postdraw_o)
+
+ENT:AddHook("PreDrawPart", "customlighting", predraw_o)
+
+ENT:AddHook("DrawPart", "customlighting", postdraw_o)

--- a/lua/entities/gmod_tardis_interior/modules/cl_render.lua
+++ b/lua/entities/gmod_tardis_interior/modules/cl_render.lua
@@ -16,28 +16,28 @@ local function predraw_o(self)
     if self.metadata.Interior.Light == nil then return end --because for some reason SOMEONE OUT THERE didn't define a light.
     render.SuppressEngineLighting(true)
     --render.SetLightingMode(1)
-
-    render.ResetModelLighting(0.5, 0.5, 0.5)
+    render.ResetModelLighting(0.3, 0.3, 0.3)
     local light=self.metadata.Interior.Light
     local lights=self.metadata.Interior.Lights
     local warning = self.exterior:GetData("health-warning", false)
     local c=light.color
     local warnc = light.warncolor or c
     local lcolor = (warning) and warnc:ToVector() or c:ToVector()
-    if self:CallHook("ShouldDrawLight") == false then 
+    local tab={}
+    if self:CallHook("ShouldDrawLight",nil,light)==false then 
         render.ResetModelLighting(0.05, 0.05, 0.05)
         render.SetLocalModelLights()
-        return 
+    else
+        table.insert(tab,{
+            type=MATERIAL_LIGHT_POINT,
+            color=lcolor*light.brightness,
+            pos = self:LocalToWorld(light.pos),
+            quadraticFalloff=20,
+        })
     end
-    --render.SetModelLighting(BOX_TOP, 1, 2, 3)
-    local tab={{
-        type=MATERIAL_LIGHT_POINT,
-        color=lcolor*light.brightness,
-        pos = self:LocalToWorld(light.pos),
-        quadraticFalloff=20,
-    }}
     if lights then
         for _,light in pairs(lights) do
+            if self:CallHook("ShouldDrawLight",nil,light)==false then return end
             local c=light.color
             local warnc = light.warncolor or c
             local lcolor = (warning) and warnc:ToVector() or c:ToVector()

--- a/lua/entities/gmod_tardis_interior/modules/cl_render.lua
+++ b/lua/entities/gmod_tardis_interior/modules/cl_render.lua
@@ -13,6 +13,7 @@ TARDIS:AddSetting({
 
 local function predraw_o(self)
     if not TARDIS:GetSetting("lightoverride-enabled",false,LocalPlayer()) then return end
+    if self.metadata.Interior.Light == nil then return end --because for some reason SOMEONE OUT THERE didn't define a light.
     render.SuppressEngineLighting(true)
     --render.SetLightingMode(1)
 

--- a/lua/entities/gmod_tardis_interior/modules/cl_render.lua
+++ b/lua/entities/gmod_tardis_interior/modules/cl_render.lua
@@ -20,7 +20,10 @@ local function predraw_o(self)
     render.ResetModelLighting(0.5, 0.5, 0.5)
     local light=self.metadata.Interior.Light
     local lights=self.metadata.Interior.Lights
-    local c = light.color:ToVector()
+    local warning = self.exterior:GetData("health-warning", false)
+    local c=light.color
+    local warnc = light.warncolor or c
+    local lcolor = (warning) and warnc:ToVector() or c:ToVector()
     if self:CallHook("ShouldDrawLight") == false then 
         render.ResetModelLighting(0.05, 0.05, 0.05)
         render.SetLocalModelLights()
@@ -29,15 +32,18 @@ local function predraw_o(self)
     --render.SetModelLighting(BOX_TOP, 1, 2, 3)
     local tab={{
         type=MATERIAL_LIGHT_POINT,
-        color=light.color:ToVector()*light.brightness,
+        color=lcolor*light.brightness,
         pos = self:LocalToWorld(light.pos),
         quadraticFalloff=20,
     }}
     if lights then
         for _,light in pairs(lights) do
+            local c=light.color
+            local warnc = light.warncolor or c
+            local lcolor = (warning) and warnc:ToVector() or c:ToVector()
             local tab2 = {
                 type=MATERIAL_LIGHT_POINT,
-                color=light.color:ToVector()*light.brightness,
+                color=lcolor*light.brightness,
                 pos = self:LocalToWorld(light.pos),
                 quadraticFalloff=10,
             }

--- a/lua/entities/gmod_tardis_interior/modules/cl_render.lua
+++ b/lua/entities/gmod_tardis_interior/modules/cl_render.lua
@@ -11,7 +11,7 @@ TARDIS:AddSetting({
 })
 
 local function predraw_o(self)
-    if not TARDIS:GetSetting("lightoverride-enabled",false,LocalPlayer()) then return end
+    if not TARDIS:GetSetting("lightoverride-enabled",false) then return end
     if self.metadata.Interior.Light == nil then return end --because for some reason SOMEONE OUT THERE didn't define a light.
     --render.SetLightingMode(1)
     local light=self.metadata.Interior.Light

--- a/lua/entities/gmod_tardis_interior/modules/sh_cloisterbells.lua
+++ b/lua/entities/gmod_tardis_interior/modules/sh_cloisterbells.lua
@@ -50,5 +50,5 @@ function ENT:ToggleCloisters()
 end
 
 ENT:AddHook("HealthWarningToggled","cloisters",function(self, on)
-    ENT:SetCloisters(on)
+    self:SetCloisters(on)
 end)

--- a/lua/entities/gmod_tardis_interior/modules/sh_cloisterbells.lua
+++ b/lua/entities/gmod_tardis_interior/modules/sh_cloisterbells.lua
@@ -1,1 +1,54 @@
 -- Cloisterbells
+if CLIENT then
+    TARDIS:AddSetting({
+        id="cloistersound",
+        name="Cloister bells",
+        desc="Whether the warning bells can be heard on the interior or not",
+        section="Sound",
+        value=true,
+        type="bool",
+        option=true
+    })
+
+    ENT:AddHook("OnRemove","Cloisters",function(self)
+        if self.CloisterLoop then
+            self.CloisterLoop:Stop()
+            self.CloisterLoop = nil
+        end
+    end)
+
+    ENT:AddHook("ShouldTurnOnCloisters","cloisters",function(self)
+        return self:GetData("cloisters",false)
+    end)
+
+    ENT:AddHook("Think", "cloistersound", function(self)
+        local shouldon=self:CallHook("ShouldTurnOnCloisters")
+        local shouldoff=self:CallHook("ShouldTurnOffCloisters")
+
+        local sound = self.metadata.Interior.Sounds.Cloister
+
+        if TARDIS:GetSetting("cloistersound") and TARDIS:GetSetting("sound") then
+            if shouldon and (not shouldoff) then
+                if not self.CloisterLoop then
+                    self.CloisterLoop = CreateSound(self, sound)
+                end
+                self.CloisterLoop:Play()
+            elseif self.CloisterLoop then
+                self.CloisterLoop:Stop()
+                self.CloisterLoop = nil
+            end
+        end
+    end)
+end
+
+function ENT:SetCloisters(on)
+    self:SetData("cloisters",on,true)
+end
+
+function ENT:ToggleCloisters()
+    self:SetCloisters(not self:GetData("cloisters",false))
+end
+
+ENT:AddHook("HealthWarningToggled","cloisters",function(self, on)
+    ENT:SetCloisters(on)
+end)

--- a/lua/entities/gmod_tardis_interior/modules/sh_cloisterbells.lua
+++ b/lua/entities/gmod_tardis_interior/modules/sh_cloisterbells.lua
@@ -18,13 +18,12 @@ if CLIENT then
     end)
 
     ENT:AddHook("ShouldTurnOnCloisters","cloisters",function(self)
-        return self:GetData("cloisters",false)
+        return self:GetData("cloisters")
     end)
 
     ENT:AddHook("Think", "cloistersound", function(self)
         local shouldon=self:CallHook("ShouldTurnOnCloisters")
         local shouldoff=self:CallHook("ShouldTurnOffCloisters")
-
         local sound = self.metadata.Interior.Sounds.Cloister
 
         if TARDIS:GetSetting("cloistersound") and TARDIS:GetSetting("sound") then

--- a/lua/entities/gmod_tardis_interior/modules/sh_cloisterbells.lua
+++ b/lua/entities/gmod_tardis_interior/modules/sh_cloisterbells.lua
@@ -1,0 +1,1 @@
+-- Cloisterbells

--- a/lua/entities/gmod_tardis_interior/modules/sh_controlsequences.lua
+++ b/lua/entities/gmod_tardis_interior/modules/sh_controlsequences.lua
@@ -98,7 +98,7 @@ if SERVER then
 
     ENT:AddHook("CanUsePart", "csequence-disable", function(self, part, a)
         if part.InSequence then
-            return false, true
+            return false
         end
     end)
 
@@ -107,7 +107,7 @@ if SERVER then
         local curseq = self:GetData("cseq-curseq","none")
         for _,v in pairs(sequences[curseq].Controls) do
             local p = TARDIS:GetPart(self,v)
-            p.InSequence = false
+            p.InSequence = nil
         end
         self:SetData("cseq-step",nil)
         self:SetData("cseq-curseq",nil)

--- a/lua/entities/gmod_tardis_interior/modules/sh_controlsequences.lua
+++ b/lua/entities/gmod_tardis_interior/modules/sh_controlsequences.lua
@@ -60,7 +60,7 @@ if SERVER then
         local active = self:GetData("cseq-active",false)
         local step = self:GetData("cseq-step")
         if active==false and sequences[id] then
-            local allowed = self:CallHook("controlsequence-canstart")
+            local allowed = self:CallHook("CanStartControlSequence")
             if allowed==false then return end
             self:EmitSound(self.metadata.Interior.Sounds.SequenceOK)
             self:SetData("cseq-active", true)
@@ -91,7 +91,7 @@ if SERVER then
             end
         end
     end)
-    ENT:AddHook("controlsequence-canstart", "settingquery", function(self)
+    ENT:AddHook("CanStartControlSequence", "settingquery", function(self)
         local result = TARDIS:GetSetting("csequences-enabled",false,self:GetCreator())
         return true
     end)

--- a/lua/entities/gmod_tardis_interior/modules/sh_security.lua
+++ b/lua/entities/gmod_tardis_interior/modules/sh_security.lua
@@ -1,0 +1,19 @@
+--Security System (Isomorphic)
+TARDIS:AddSetting({
+    id="security",
+    name="Isomorphic Security",
+    value=false,
+    type="bool",
+    networked=true,
+    option=true,
+    desc="Whether or not people other than you can use your TARDIS' controls."
+})
+
+--Hooks
+ENT:AddHook("CanUsePart","security",function(self,part,ply)
+    if TARDIS:GetSetting("security",false,self:GetCreator())==true and (ply~=self:GetCreator()) then
+        if part.ID == "door" then return end
+        ply:ChatPrint("This TARDIS uses Isomorphic Security. You may not use any controls.")
+        return false,false
+    end
+end)

--- a/lua/entities/gmod_tardis_interior/modules/sv_health.lua
+++ b/lua/entities/gmod_tardis_interior/modules/sv_health.lua
@@ -28,7 +28,7 @@ function ENT:StopCloisters()
     self.CloisterLoop:Stop()
 end
 
-ENT:AddHook("health-depleted", "interior-death", function(self)
+ENT:AddHook("OnHealthDepleted", "interior-death", function(self)
     util.ScreenShake(self:GetPos(), 10, 10, 1, 10)
     self:Explode()
 end)

--- a/lua/entities/gmod_tardis_interior/modules/sv_health.lua
+++ b/lua/entities/gmod_tardis_interior/modules/sv_health.lua
@@ -3,12 +3,29 @@ ENT:AddHook("OnTakeDamage", "Health", function(self, dmginfo)
     self.exterior:ChangeHealth(newhealth)
 end)
 
+ENT:AddHook("Initialize", "Health", function(self)
+    self.CloisterLoop = CreateSound(self, self.metadata.Interior.Sounds.Cloister)
+end)
+
+ENT:AddHook("OnRemove", "Health", function(self)
+    self:StopCloisters()
+    self.CloisterLoop = null
+end)
+
 function ENT:Explode()
     local explode = ents.Create("env_explosion")
     explode:SetPos( self:LocalToWorld(Vector(0,0,0)) )
     explode:SetOwner( self )
     explode:Spawn()
     explode:Fire("Explode", 0, 0 )
+end
+
+function ENT:StartCloisters()
+    self.CloisterLoop:Play()
+end
+
+function ENT:StopCloisters()
+    self.CloisterLoop:Stop()
 end
 
 ENT:AddHook("health-depleted", "interior-death", function(self)

--- a/lua/entities/gmod_tardis_interior/modules/sv_health.lua
+++ b/lua/entities/gmod_tardis_interior/modules/sv_health.lua
@@ -3,29 +3,12 @@ ENT:AddHook("OnTakeDamage", "Health", function(self, dmginfo)
     self.exterior:ChangeHealth(newhealth)
 end)
 
-ENT:AddHook("Initialize", "Health", function(self)
-    self.CloisterLoop = CreateSound(self, self.metadata.Interior.Sounds.Cloister, RecipientFilter():AddAllPlayers())
-end)
-
-ENT:AddHook("OnRemove", "Health", function(self)
-    self:StopCloisters()
-    self.CloisterLoop = null
-end)
-
 function ENT:Explode()
     local explode = ents.Create("env_explosion")
     explode:SetPos( self:LocalToWorld(Vector(0,0,0)) )
     explode:SetOwner( self )
     explode:Spawn()
     explode:Fire("Explode", 0, 0 )
-end
-
-function ENT:StartCloisters()
-    self.CloisterLoop:Play()
-end
-
-function ENT:StopCloisters()
-    self.CloisterLoop:Stop()
 end
 
 ENT:AddHook("OnHealthDepleted", "interior-death", function(self)

--- a/lua/entities/gmod_tardis_interior/modules/sv_health.lua
+++ b/lua/entities/gmod_tardis_interior/modules/sv_health.lua
@@ -4,7 +4,7 @@ ENT:AddHook("OnTakeDamage", "Health", function(self, dmginfo)
 end)
 
 ENT:AddHook("Initialize", "Health", function(self)
-    self.CloisterLoop = CreateSound(self, self.metadata.Interior.Sounds.Cloister)
+    self.CloisterLoop = CreateSound(self, self.metadata.Interior.Sounds.Cloister, RecipientFilter():AddAllPlayers())
 end)
 
 ENT:AddHook("OnRemove", "Health", function(self)

--- a/lua/entities/gmod_tardis_interior/shared.lua
+++ b/lua/entities/gmod_tardis_interior/shared.lua
@@ -23,6 +23,17 @@ function ENT:RemoveHook(name,id)
 	end
 end
 
+function ENT:GetHooksTable()
+    return hooks
+end
+
+function ENT:ListHooks()
+    print("[Interior]"..(SERVER and "[Server]" or "[Client]"))
+    for h in pairs(hooks) do
+        print(h)
+    end
+end
+
 function ENT:CallHook(name,...)
 	local a,b,c,d,e,f
 	a,b,c,d,e,f=self.BaseClass.CallHook(self,name,...)
@@ -31,7 +42,7 @@ function ENT:CallHook(name,...)
 	end
 	if not hooks[name] then return end
 	for k,v in pairs(hooks[name]) do
-		a,b,c,d,e,f = v(self,...)
+        a,b,c,d,e,f = v(self,...)
 		if a~=nil then
 			return a,b,c,d,e,f
 		end

--- a/lua/entities/gmod_tardis_part/init.lua
+++ b/lua/entities/gmod_tardis_part/init.lua
@@ -3,6 +3,7 @@ AddCSLuaFile('shared.lua')
 include('shared.lua')
 
 function ENT:OnTakeDamage(dmginfo)
+    if not self.ShouldTakeDamage then return end
 	if self.parent:CallHook("ShouldTakeDamage",dmginfo)==false then return end
 	self.parent:CallHook("OnTakeDamage", dmginfo)
 end

--- a/lua/tardis/cl_hud.lua
+++ b/lua/tardis/cl_hud.lua
@@ -5,10 +5,13 @@ hook.Add("HUDPaint", "TARDISRewrite-HUD", function()
     if not (LocalPlayer():GetTardisData("interior") or LocalPlayer():GetTardisData("exterior")) then return end
     local tardis = LocalPlayer():GetTardisData("exterior")
     if not IsValid(tardis) then return end
+    local sw = ScrW()
+    local sh = ScrH()
     local health = tardis:GetHealthPercent()
     local minwidth = 160
     local width = minwidth + math.Clamp( ((#tostring(health)-4) * 30), 0, math.huge)
-    local height = 120
+    local height = (sw >= 800) and 120 or 95
+    local healthfont = (height == 120) and "TARDIS-Large" or "TARDIS-Med"
     local x = (ScrW()-width)*0.02
     local y = (ScrH()-height)*0.025
     draw.RoundedBox( 10, x, y, width, height, NamedColor("BgColor") )
@@ -17,5 +20,5 @@ hook.Add("HUDPaint", "TARDISRewrite-HUD", function()
     if (health > 20) then textcolor = NamedColor("FgColor")
     else textcolor = NamedColor("Caution") end
     draw.DrawText( "TARDIS", "TARDIS-PageName", x+10, y+10, textcolor, TEXT_ALIGN_LEFT )
-    draw.DrawText( health, "TARDIS-Large", x+10, y+45, textcolor, TEXT_ALIGN_LEFT )
+    draw.DrawText( health, healthfont, x+10, y+45, textcolor, TEXT_ALIGN_LEFT )
 end)

--- a/lua/tardis/cl_hud.lua
+++ b/lua/tardis/cl_hud.lua
@@ -5,14 +5,17 @@ hook.Add("HUDPaint", "TARDISRewrite-HUD", function()
     if not (LocalPlayer():GetTardisData("interior") or LocalPlayer():GetTardisData("exterior")) then return end
     local tardis = LocalPlayer():GetTardisData("exterior")
     if not IsValid(tardis) then return end
-    local health = tardis:GetData("health-val", 0)
+    local health = tardis:GetHealthPercent()
     local minwidth = 160
     local width = minwidth + math.Clamp( ((#tostring(health)-4) * 30), 0, math.huge)
     local height = 120
     local x = (ScrW()-width)*0.02
     local y = (ScrH()-height)*0.025
     draw.RoundedBox( 10, x, y, width, height, NamedColor("BgColor") )
+    local textcolor
     local textcolor = (health > 0) and NamedColor("FgColor") or NamedColor("Caution")
+    if (health > 20) then textcolor = NamedColor("FgColor")
+    else textcolor = NamedColor("Caution") end
     draw.DrawText( "TARDIS", "TARDIS-PageName", x+10, y+10, textcolor, TEXT_ALIGN_LEFT )
     draw.DrawText( health, "TARDIS-Large", x+10, y+45, textcolor, TEXT_ALIGN_LEFT )
 end)

--- a/lua/tardis/cl_interiorsetting.lua
+++ b/lua/tardis/cl_interiorsetting.lua
@@ -22,7 +22,7 @@ TARDIS:AddGUISetting("Interior", function(self,frame,screen)
 				button:SetFont("TARDIS-Default")
 				button.DoClick = function()
 					TARDIS:SetSetting("interior",v[2],true)
-					LocalPlayer():ChatPrint("TARDIS interior changed. Respawn the TARDIS for changes to apply.")
+					LocalPlayer():ChatPrint("TARDIS interior changed. Respawn or repair the TARDIS for changes to apply.")
 				end
 				table.insert(buttons,button)
 			end

--- a/lua/tardis/cl_options.lua
+++ b/lua/tardis/cl_options.lua
@@ -4,7 +4,7 @@ function TARDIS:ChangeOption(id,data)
 	local frame = vgui.Create("DFrame")
 	frame:SetSkin("TARDIS")
 	frame:SetTitle("TARDIS Interface")
-	frame:SetSize(250,125)
+	frame:SetSize(250,150)
 	frame:SetDraggable(false)
 	frame:SetBackgroundBlur(true)
 	

--- a/lua/tardis/cl_options.lua
+++ b/lua/tardis/cl_options.lua
@@ -17,7 +17,7 @@ function TARDIS:ChangeOption(id,data)
 	text:SetPos(10,30)
 	text:SetTextColor(color_white)
 	
-	local value=TARDIS:GetSetting(id,data.value,LocalPlayer())
+	local value=TARDIS:GetSetting(id,data.value)
 	
 	local update
 	if data.type=="number" then

--- a/lua/tardis/interiors/base.lua
+++ b/lua/tardis/interiors/base.lua
@@ -61,7 +61,8 @@ T.Exterior={
 			open="drmatt/tardis/door_open.wav",
 			close="drmatt/tardis/door_close.wav"
 		},
-		FlightLoop="drmatt/tardis/flight_loop.wav"
+		FlightLoop="drmatt/tardis/flight_loop.wav",
+		Cloister="tardis/cloisterbell_loop.wav"
 	},
 	Parts={
 		vortex={

--- a/lua/tardis/interiors/base.lua
+++ b/lua/tardis/interiors/base.lua
@@ -62,7 +62,6 @@ T.Exterior={
 			close="drmatt/tardis/door_close.wav"
 		},
 		FlightLoop="drmatt/tardis/flight_loop.wav",
-		Cloister="tardis/cloisterbell_loop.wav"
 	},
 	Parts={
 		vortex={

--- a/lua/tardis/interiors/default.lua
+++ b/lua/tardis/interiors/default.lua
@@ -94,7 +94,7 @@ T.Interior={
 		},
 		door=true
 	},
-	/*
+	--[[
 	CustomPortals={
 		test={
 			entry={
@@ -113,7 +113,7 @@ T.Interior={
 			}
 		}
 	}
-	*/
+	--]]
 }
 T.Exterior={
 	Parts={

--- a/lua/tardis/interiors/default.lua
+++ b/lua/tardis/interiors/default.lua
@@ -16,6 +16,7 @@ T.Interior={
 	},
 	Light={
 		color=Color(0,100,255),
+		warncolor=Color(255,100,0),
 		pos=Vector(0,0,0),
 		brightness=8
 	},

--- a/lua/tardis/interiors/legacy.lua
+++ b/lua/tardis/interiors/legacy.lua
@@ -18,8 +18,17 @@ T.Interior={
 	},
 	Light={
 		color=Color(255,50,0),
+		warncolor=Color(255,0,0),
 		pos=Vector(0,0,120),
 		brightness=5
+	},
+	Lights={
+		{
+			color=Color(0,255,0),
+			pos=Vector(0,0,-50),
+			brightness=2,
+			nopower=true
+		}
 	},
 	Portal={
 		pos=Vector(316.7,334.9,-36.5),

--- a/lua/tardis/parts/console.lua
+++ b/lua/tardis/parts/console.lua
@@ -5,6 +5,7 @@ PART.ID = "console"
 PART.Name = "The Console"
 PART.AutoSetup = true
 PART.Collision = true
+PART.ShouldTakeDamage = true
 
 if SERVER then	
 	function PART:Use(ply)

--- a/lua/tardis/parts/door.lua
+++ b/lua/tardis/parts/door.lua
@@ -10,6 +10,7 @@ PART.ClientThinkOverride = true
 PART.ClientDrawOverride = true
 PART.Collision = true
 PART.NoStrictUse = true
+PART.ShouldTakeDamage = true
 
 if SERVER then
 	function PART:Initialize()	

--- a/lua/tardis/screens/sh_destination.lua
+++ b/lua/tardis/screens/sh_destination.lua
@@ -99,12 +99,9 @@ TARDIS:AddScreen("Destination", {menu=false}, function(self,ext,int,frame,screen
 		end
 		if namebox:GetText() ~= "" then
 			name = namebox:GetText()
-		end
-		if pos ~= 0 and ang ~= 0 and name ~= "" then
-			return pos,ang,name
-		else
-			return false,false,false
-		end
+        end
+        if name == "" then name = "Unnamed" end
+		return pos,ang,name
 	end
 	if ext:GetData("demat-pos") and ext:GetData("demat-ang") then
 		updatetextinputs(ext:GetData("demat-pos"), ext:GetData("demat-ang"),"Current Set Destination")
@@ -161,12 +158,13 @@ TARDIS:AddScreen("Destination", {menu=false}, function(self,ext,int,frame,screen
 		function(text)
 			name = text
 			Derma_Query(
-				"Use current TARDIS position and rotation?",
+				"Use current TARDIS position and rotation?\nSelecting 'No' will use the information on the inputs.",
 				"New Location",
 				"Yes",
 				function() 
 						pos = ext:GetPos() 
-						ang = ext:GetAngles() 
+                        ang = ext:GetAngles() 
+                        if name == "" then name = "Unnamed" end
 						TARDIS:AddLocation(pos,ang,name,map) 
 						updatelist() 
 				end,
@@ -186,7 +184,7 @@ TARDIS:AddScreen("Destination", {menu=false}, function(self,ext,int,frame,screen
 	edit:SetEnabled(false)
 	function edit:DoClick()
 		pendingchanges = true
-		local pos,ang,name = fetchtextinputs()
+        local pos,ang,name = fetchtextinputs()
 		local index = list:GetSelectedLine()
 		if not index then return end
 		TARDIS:UpdateLocation(pos,ang,name,map,index)
@@ -258,7 +256,7 @@ TARDIS:AddScreen("Destination", {menu=false}, function(self,ext,int,frame,screen
 	confirm:SetFont("TARDIS-Default")
 	function confirm:DoClick()
 		local pos,ang = fetchtextinputs()
-		if pos ~= false then
+		if pos ~= nil then
 			ext:SendMessage("destination-demat", function()
 				net.WriteVector(pos)
 				net.WriteAngle(ang)

--- a/lua/tardis/sh_parts.lua
+++ b/lua/tardis/sh_parts.lua
@@ -65,7 +65,7 @@ local overrides={
         if self.ExteriorPart then
             allowed, animate = self.exterior:CallHook("CanUsePart",self,a)
         else
-            allowed, animate =  self.interior:CallHook("CanUsePart",self,a)
+            allowed, animate = self.interior:CallHook("CanUsePart",self,a)
         end
 		if allowed~=false then
 			res=self.o.Use(self,a,...)

--- a/lua/tardis/sh_parts.lua
+++ b/lua/tardis/sh_parts.lua
@@ -70,9 +70,9 @@ local overrides={
 		if SERVER and (animate~=false) and (res~=false) then
 			local on = self:GetOn()
 			if self.SoundOn and on then
-				self:EmitSound(self.SoundOn)
-			elseif self.SoundOff and (not on) then
 				self:EmitSound(self.SoundOff)
+			elseif self.SoundOff and (not on) then
+				self:EmitSound(self.SoundOn)
 			elseif self.Sound then
 				self:EmitSound(self.Sound)
 			end

--- a/lua/tardis/sh_parts.lua
+++ b/lua/tardis/sh_parts.lua
@@ -61,8 +61,12 @@ local overrides={
 		local call=false
 		local res
 		if (not self.NoStrictUse) and IsValid(a) and a:IsPlayer() and a:GetEyeTraceNoCursor().Entity~=self then return end
-		local allowed, animate = (self.ExteriorPart and self.exterior:CallHook("CanUsePart",self,a) or self.interior:CallHook("CanUsePart",self,a))
-		
+        local allowed, animate
+        if self.ExteriorPart then
+            allowed, animate = self.exterior:CallHook("CanUsePart",self,a)
+        else
+            allowed, animate =  self.interior:CallHook("CanUsePart",self,a)
+        end
 		if allowed~=false then
 			res=self.o.Use(self,a,...)
 		end


### PR DESCRIPTION
Opening this to keep track of changes and closed issues since I've made a bit of a mess on the commit messages (whoops)
Completed all checkpoints of #327, effectively closing #327.
### Added
* Cloisterbells (play below 20% health, closes #240)
* Smoke effects on the exterior
* Warning light colours (both main and secondary lights)
* No-power lights
* TARDIS interior can now change on repair
* Projected light on the exterior to simulate light "bleeding" out (Closes #290)
* Experimental map lighting override (Closes #287, looks better on interiors with some baked lighting or ambient occlusion)
* Basic isomorphic (owner-only) security. Will be expanded to allow certain people to use controls in the future (as detailed in #60)
### Changed
* Parts no longer get damaged when shot/hit by default. Can be overridden by setting `PART.ShouldTakeDamage` to true.
* Destination coordinates can now be updated from the UI by changing whatever's in the text fields and hitting "Set"
* Health is now displayed in percent of maximum health
* The TARDIS can no longer float when dead
* You can set your TARDIS to "repair" when the selected interior doesn't match the current one
### Fixed
* Health HUD *should* scale better on smaller displays/resolutions
* Renamed some hooks to match the naming convention of literally all other hooks
* Previous weapon isn't set if we're already in thirdperson view (Fixes #341)
* Fast remat no longer skips transparency phasing occasionally (Fixes #332)
* Lighting override properly accounts for secondary no-power lights
* Lighting override no longer keeps main light on if there are no secondary lights (Fixes #343)

As per the Next Update milestone, this isn't ready to merge yet because I haven't found a fix for #334. I might skip this one issue for this round though.