### PR TITLE
Allow traces to route through portals properly and improve custom portals support

### DIFF
--- a/addon.json
+++ b/addon.json
@@ -8,6 +8,7 @@
 		"*.txt",
 		"*.git*",
 		"*.fgd",
-		"*.psd"
+		"*.psd",
+		"CODEOWNERS"
 	]
 }

--- a/lua/entities/gmod_tardis/modules/sh_portals.lua
+++ b/lua/entities/gmod_tardis/modules/sh_portals.lua
@@ -1,0 +1,38 @@
+-- Portals
+
+if SERVER then
+    ENT:AddHook("ShouldTeleportPortal", "portals", function(self,portal,ent)
+        if not self:DoorOpen() or ent.TardisPart then
+            return false
+        end
+	end)
+else
+    ENT:AddHook("ShouldRenderPortal", "portals", function(self,portal,exit,origin)
+        local dont,black = self:CallHook("ShouldNotRenderPortal",self,portal,exit,origin)
+        if dont==nil then
+            local other = self.interior
+            if IsValid(other) then
+                dont,black = other:CallHook("ShouldNotRenderPortal",self,portal,exit,origin)
+            end
+        end
+        if dont then
+            return false, black
+        elseif (not (self.DoorOpen and self:DoorOpen(true))) then
+            return false
+        elseif (not TARDIS:GetSetting("portals-enabled")) then
+            return false
+        end
+    end)
+end
+
+ENT:AddHook("ShouldTracePortal", "portals", function(self,portal)
+    if not self:DoorOpen() then
+        return false
+    end
+end)
+
+ENT:AddHook("TraceFilterPortal", "portals", function(self,portal)
+    if self.interior and portal == self.interior.portals.exterior then
+        return self.interior:GetPart("door")
+    end
+end)

--- a/lua/entities/gmod_tardis_interior/modules/cl_scanner.lua
+++ b/lua/entities/gmod_tardis_interior/modules/cl_scanner.lua
@@ -5,3 +5,27 @@ ENT:AddHook("ShouldDraw", "scanner", function(self)
 		return false
 	end
 end)
+
+ENT:AddHook("ShouldNotRenderPortal","scanner",function(self,parent,portal)
+	if self.scannerrender and portal==self.portals.interior then
+		return true
+	end
+end)
+
+ENT:AddHook("PreScannerRender", "scanner", function(self)
+	for k,v in pairs(self.props) do
+		if IsValid(k) then
+			k.olddraw=k:GetNoDraw()
+			k:SetNoDraw(true)
+		end
+	end
+end)
+
+ENT:AddHook("PostScannerRender", "scanner", function(self)
+	for k,v in pairs(self.props) do
+		if IsValid(k) and k.olddraw~=nil then
+			k:SetNoDraw(k.olddraw)
+			k.olddraw=nil
+		end
+	end
+end)

--- a/lua/entities/gmod_tardis_interior/modules/sh_parts.lua
+++ b/lua/entities/gmod_tardis_interior/modules/sh_parts.lua
@@ -10,6 +10,10 @@ ENT:AddHook("Initialize","parts",function(self)
 	end
 end)
 
+ENT:AddHook("Cordon","parts",function(self,class,ent)
+	if ent.TardisPart then return false end
+end)
+
 function ENT:GetPart(id)
 	return self.parts and self.parts[id] or NULL
 end

--- a/lua/tardis/parts/door.lua
+++ b/lua/tardis/parts/door.lua
@@ -7,7 +7,6 @@ PART.Model = "models/drmatt/tardis/exterior/door.mdl"
 PART.AutoSetup = true
 PART.AutoPosition = false
 PART.ClientThinkOverride = true
-PART.ClientDrawOverride = true
 PART.Collision = true
 PART.NoStrictUse = true
 PART.ShouldTakeDamage = true
@@ -18,9 +17,11 @@ if SERVER then
 		self:SetBodygroup(2,1) -- Lit sign
 		
 		if self.ExteriorPart then
+			self.ClientDrawOverride = true
 			self:SetSolid(SOLID_VPHYSICS)
 			--self:SetCollisionGroup(COLLISION_GROUP_WORLD)
 		elseif self.InteriorPart then
+			self.DrawThroughPortal = true
 			self:SetBodygroup(3,1) -- 3D sign
 			table.insert(self.interior.stuckfilter, self)
 		end

--- a/lua/tardis/screens/cl_scanner.lua
+++ b/lua/tardis/screens/cl_scanner.lua
@@ -107,6 +107,7 @@ hook.Add("RenderScene", "TARDISI_Scanner", function(pos,ang)
 					local camAngle = ext:LocalToWorldAngles(v.scannerang)
 					if IsValid(int) then
 						int.scannerrender=true
+						int:CallHook("PreScannerRender")
 					end
 					render.RenderView({
 						x = 0,
@@ -124,6 +125,7 @@ hook.Add("RenderScene", "TARDISI_Scanner", function(pos,ang)
 					})
 					if IsValid(int) then
 						int.scannerrender=false
+						int:CallHook("PostScannerRender")
 					end
 				render.SetRenderTarget( oldRT )
 			end


### PR DESCRIPTION
- See Doors changes also included from https://github.com/MattJeanes/Doors/pull/11
- Scanner now hides the interior in the sky properly
- Custom portals can now be linked to a part and they switch on and off with them to improve performance and stop accidental teleports