### PR TITLE
Sonic dispenser 

### DIFF
--- a/lua/entities/gmod_tardis/modules/sh_sonicdispenser.lua
+++ b/lua/entities/gmod_tardis/modules/sh_sonicdispenser.lua
@@ -10,13 +10,20 @@ TARDIS:AddControl({
 	id = "sonic_dispenser",
 	int_func=function(self,ply)
 		if TARDIS:IsSonicInstalled() then
-			if ply:GetWeapon("swep_sonicsd") == NULL then
-				ply:Give("swep_sonicsd")
+			local currentWeapon = ply:GetActiveWeapon()
+			if IsValid(currentWeapon) and currentWeapon:GetClass() == "swep_sonicsd" then
+				TARDIS:ErrorMessage(ply, "You are already holding a Sonic Screwdriver.")
+				return
 			end
-			TARDIS:Message(ply, "Sonic Screwdriver has been dispensed.")
+			if IsValid(ply:GetWeapon("swep_sonicsd")) then
+				TARDIS:Message(ply, "Sonic Screwdriver has been equipped.")
+			else
+				ply:Give("swep_sonicsd")
+				TARDIS:Message(ply, "Sonic Screwdriver has been dispensed.")
+			end
 			ply:SelectWeapon("swep_sonicsd")
 		else
-			TARDIS:ErrorMessage(ply, "You do not have Sonic Screwdriver addon installed. Install it for this part to work.")
+			TARDIS:ErrorMessage(ply, "You do not have the Sonic Screwdriver addon installed. Install it for this part to work.")
 		end
 	end,
 	serveronly = true,

--- a/lua/entities/gmod_tardis/modules/sh_sonicdispenser.lua
+++ b/lua/entities/gmod_tardis/modules/sh_sonicdispenser.lua
@@ -1,0 +1,25 @@
+
+function TARDIS:IsSonicInstalled()
+	if SonicSD and file.Exists("autorun/sonicsd.lua", "LUA") then
+		return true
+	end
+	return false
+end
+
+TARDIS:AddControl({
+	id = "sonic_dispenser",
+	int_func=function(self,ply)
+		if TARDIS:IsSonicInstalled() then
+			if ply:GetWeapon("swep_sonicsd") == NULL then
+				ply:Give("swep_sonicsd")
+			end
+			TARDIS:Message(ply, "Sonic Screwdriver has been dispensed.")
+			ply:SelectWeapon("swep_sonicsd")
+		else
+			TARDIS:ErrorMessage(ply, "You do not have Sonic Screwdriver addon installed. Install it for this part to work.")
+		end
+	end,
+	serveronly = true,
+	screen_button = false,
+	tip_text = "Sonic Charger",
+})

--- a/lua/tardis/interiors/default.lua
+++ b/lua/tardis/interiors/default.lua
@@ -1,7 +1,7 @@
 -- Default
 
-local function IsSonicInstalled()
-	if SonicSD and file.Exists("autorun/sonicsd.lua", "LUA") then
+local function SonicModelExists()
+	if SonicSD and file.Exists("models/weapons/c_sonicsd.mdl", "GAME") then
 		return true
 	end
 	return false
@@ -90,9 +90,8 @@ T.Interior={
 		default_blacksticks        = {pos = Vector(4.480469, -43.906372, 7),          ang = Angle(13, 0, 24.176),             tip = {pos = Vector(4.48, -43.9, 7)}},
 		default_longflighttoggle   = {pos = Vector(-37.242310, -27.915344, 7.428223), ang = Angle(338, 28.721, 15),           tip = {pos = Vector(-37.24, -27.91, 7.42)},},
 		default_dematcircuit       = {pos = Vector(-43.168457, -31.015625, 4.7),      ang = Angle(22, 209.224, 348),          tip = {pos = Vector(-43.16, -31.01, 4.7), right = true, down = true},},
-		default_sonicdispenser     = IsSonicInstalled() and
-		                             {pos = Vector(-26.048, 42.31, 1.45),             ang = Angle(9.445, 46.482, -21.861),    tip = {pos = Vector(-26.048, 42.31, 3.15), right = true, down = false}, },
-		default_sonic_inserted     = IsSonicInstalled() and
+		default_sonicdispenser     = {pos = Vector(-26.048, 42.31, 1.45),             ang = Angle(9.445, 46.482, -21.861),    tip = {pos = Vector(-26.048, 42.31, 3.15), right = true, down = false}, },
+		default_sonic_inserted     = SonicModelExists() and
 	                                 {pos = Vector(-29.748, 40.71, -20.15),           ang = Angle(-100, -90, 90),             tip = {pos = Vector(-26.048, 42.31, 3.15), right = true, down = false}, },
 		default_helmic = {
 			pos = Vector(-26, -41, 4),

--- a/lua/tardis/interiors/default.lua
+++ b/lua/tardis/interiors/default.lua
@@ -1,5 +1,12 @@
 -- Default
 
+local function IsSonicInstalled()
+	if SonicSD and file.Exists("autorun/sonicsd.lua", "LUA") then
+		return true
+	end
+	return false
+end
+
 local T={}
 T.Base="base"
 T.Name="Default"
@@ -83,6 +90,10 @@ T.Interior={
 		default_blacksticks        = {pos = Vector(4.480469, -43.906372, 7),          ang = Angle(13, 0, 24.176),             tip = {pos = Vector(4.48, -43.9, 7)}},
 		default_longflighttoggle   = {pos = Vector(-37.242310, -27.915344, 7.428223), ang = Angle(338, 28.721, 15),           tip = {pos = Vector(-37.24, -27.91, 7.42)},},
 		default_dematcircuit       = {pos = Vector(-43.168457, -31.015625, 4.7),      ang = Angle(22, 209.224, 348),          tip = {pos = Vector(-43.16, -31.01, 4.7), right = true, down = true},},
+		default_sonicdispenser     = IsSonicInstalled() and
+		                             {pos = Vector(-26.048, 42.31, 1.45),             ang = Angle(9.445, 46.482, -21.861),    tip = {pos = Vector(-26.048, 42.31, 3.15), right = true, down = false}, },
+		default_sonic_inserted     = IsSonicInstalled() and
+	                                 {pos = Vector(-29.748, 40.71, -20.15),           ang = Angle(-100, -90, 90),             tip = {pos = Vector(-26.048, 42.31, 3.15), right = true, down = false}, },
 		default_helmic = {
 			pos = Vector(-26, -41, 4),
 			ang = Angle(0, 330, 24.5),

--- a/lua/tardis/parts/default/sonic_dispenser_button.lua
+++ b/lua/tardis/parts/default/sonic_dispenser_button.lua
@@ -1,0 +1,12 @@
+-- Default Interior - Sonic charger
+
+local PART = {}
+PART.ID = "default_sonicdispenser"
+PART.Name = "Default Sonic Screwdriver Dispenser"
+PART.Control = "sonic_dispenser"
+PART.AutoSetup = true
+PART.Collision = true
+PART.Animate = true
+PART.Model = "models/drmatt/tardis/smallbutton.mdl"
+
+TARDIS:AddPart(PART)

--- a/lua/tardis/parts/default/sonic_inserted.lua
+++ b/lua/tardis/parts/default/sonic_inserted.lua
@@ -1,0 +1,12 @@
+-- Default Interior - Sonic charger
+
+local PART = {}
+PART.ID = "default_sonic_inserted"
+PART.Name = "Default Sonic Screwdriver in the charger"
+PART.Control = "sonic_dispenser"
+PART.AutoSetup = true
+PART.Collision = true
+PART.Animate = true
+PART.Model = "models/weapons/c_sonicsd.mdl"
+
+TARDIS:AddPart(PART)


### PR DESCRIPTION
Closes #147

If sonic screwdriver addon is installed, there is a sonic in the console
If it isn't or the model is missing, there's just a button which produces a warning
The control itself can be used in other TARDISes, and will not break the thing if the sonic isn't there
![изображение](https://user-images.githubusercontent.com/32988384/141369102-2166a82f-c7aa-4d0f-bbf1-926a4daa422e.png)

Made with the allowed partial use of ryanm2711's code in Brundoob's extension

P.S. It currently works in a very simple way. 
If someone wishes to add any effects/animations to it, I'll be more than happy, but I probably won't do that