### PR TITLE
A step under the default doorframe

### DIFF
--- a/lua/tardis/interiors/default.lua
+++ b/lua/tardis/interiors/default.lua
@@ -99,7 +99,19 @@ T.Interior = {
 			ang = Angle(0, -40, 0),
 			scale = 0.764,
 			matrixScale = Vector(1, 1, 1.083)
-		}
+		},
+		default_doorframe_bottom = {
+			pos = Vector(317, 335.8, -93.5),
+			ang = Angle(0, 50, 0),
+			scale = 1.14,
+			matrixScale = Vector(0.53, 1.02, 1)
+		},
+		default_doorframe_bottom2 = {
+			pos = Vector(317, 335.8, -93.5),
+			ang = Angle(0, 230, 0),
+			scale = 1.14,
+			matrixScale = Vector(0.54, 1.02, 1)
+		},
 	},
 	Controls = {
 		default_throttle           = "teleport",

--- a/lua/tardis/parts/default/default_int_doorframe.lua
+++ b/lua/tardis/parts/default/default_int_doorframe.lua
@@ -11,3 +11,22 @@ PART.CollisionUse = false
 PART.Animate = true
 
 TARDIS:AddPart(PART)
+
+local PART = {}
+PART.ID = "default_doorframe_bottom"
+PART.Name = "Default Door Frame Bottom"
+PART.Model = "models/hunter/blocks/cube025x1x025.mdl"
+PART.BypassIsomorphic = true
+PART.AutoSetup = true
+PART.Collision = false
+PART.CollisionUse = false
+PART.Animate = true
+
+function PART:Initialize()
+	self:SetMaterial("models/drmatt/tardis/tardisfloor")
+end
+
+TARDIS:AddPart(PART)
+
+PART.ID = "default_doorframe_bottom2" -- make a copy
+TARDIS:AddPart(PART)


### PR DESCRIPTION
I've just added a block with floor texture under the doorframe to fix the gap
I had to split it into 2 parts, since finding the right coordinates is extremely hard
(you can replace them with one part yourself if you like, but they shouldn't ruin performance due to simplicity)

Fixes and closes #508

![изображение](https://user-images.githubusercontent.com/32988384/150641831-7ccdba61-9ccc-4de0-af71-43497b457fc2.png)
