### PR TITLE
Support for asymmetric portals

### DIFF
--- a/lua/tardis/parts/door.lua
+++ b/lua/tardis/parts/door.lua
@@ -32,7 +32,19 @@ if SERVER then
         if portal then
             local pos=(self.posoffset or Vector(26*(self.InteriorPart and 1 or -1),0,-51.65))
             local ang=(self.angoffset or Angle(0,self.InteriorPart and 180 or 0,0))
-            pos,ang=LocalToWorld(pos,ang,portal.pos,portal.ang)
+
+            local portal_pos = portal.pos
+            local portal_ang = portal.ang
+
+            if self.use_exit_point_offset and portal.exit_point_offset then
+                portal_pos = portal_pos + portal.exit_point_offset.pos
+                portal_ang = portal_ang + portal.exit_point_offset.ang
+            elseif self.use_exit_point_offset and portal.exit_point then
+                portal_pos = portal.exit_point.pos
+                portal_ang = portal.exit_point.ang
+            end
+
+            pos,ang=LocalToWorld(pos,ang,portal_pos,portal_ang)
             self:SetPos(self.parent:LocalToWorld(pos))
             self:SetAngles(self.parent:LocalToWorldAngles(ang))
             self:SetParent(self.parent)


### PR DESCRIPTION
This is a combined pull request for the [TARDIS](https://github.com/MattJeanes/TARDIS/pull/664), [Doors](https://github.com/MattJeanes/Doors/pull/24) and [world-portals](https://github.com/MattJeanes/world-portals/pull/32)

**Usage example:** https://discord.com/channels/811697995421581322/917409402787594250/984723574155771914
Current version should work better than the one from the video

**What to test with:** 1972 addon (https://gitlab.com/kasterborous/karmal/tardis-1972), branch: `asymmetric_portals`



