### PR TITLE
Made interrupting teleport more smooth

### DIFF
--- a/lua/entities/gmod_tardis/modules/teleport/sh_tp_problematic.lua
+++ b/lua/entities/gmod_tardis/modules/teleport/sh_tp_problematic.lua
@@ -430,14 +430,10 @@ ENT:AddHook("Think", "interrupted-teleport", function(self)
     end
 end)
 
-ENT:AddHook("CanTogglePower","interrupted-teleport", function(self)
+ENT:AddHook("CanTogglePower", "interrupted-teleport", function(self)
     if self:GetData("teleport-interrupted", false) then
         return false
     end
-end)
-
-ENT:AddHook("InterruptTeleport", "demat", function(self)
-
 end)
 
 


### PR DESCRIPTION
* Fixed: Interrupting teleport doesn't turn off the flight mode and floating any more

* Tweaked: You can use the handbrake while dematerialising to cancel it, and the TARDIS will not explode
It will explode if pressed in the vortex or while materialising
That is screen-accurate with Clara using the handbrake in "Kill the Moon"

