### PR TITLE
[HotFix update request] Extra hooks and small fixes

### DIFF
--- a/lua/entities/gmod_tardis/modules/sh_cloak.lua
+++ b/lua/entities/gmod_tardis/modules/sh_cloak.lua
@@ -40,6 +40,7 @@ if SERVER then
         if (not self:GetData("teleport")) and (not self:GetData("vortex")) then
             self:DrawShadow(not on)
         end
+        self:CallHook("CloakToggled", on)
         return true
     end
     

--- a/lua/entities/gmod_tardis/modules/sh_flight.lua
+++ b/lua/entities/gmod_tardis/modules/sh_flight.lua
@@ -103,6 +103,7 @@ if SERVER then
             end
         end
         self:SetData("flight",on,true)
+        self:CallCommonHook("FlightToggled", on)
         self:SetFloat(on)
         return true
     end

--- a/lua/entities/gmod_tardis/modules/sh_float.lua
+++ b/lua/entities/gmod_tardis/modules/sh_float.lua
@@ -68,6 +68,7 @@ if SERVER then
         if (not on) and self:CallHook("CanTurnOffFloat")==false then return end
         if (on) and self:CallHook("CanTurnOnFloat")==false then return end
         self:SetData("float",on,true)
+        self:CallCommonHook("FloatToggled", on)
         self.phys:EnableGravity(not on)
         return true
     end

--- a/lua/entities/gmod_tardis/modules/sh_hads.lua
+++ b/lua/entities/gmod_tardis/modules/sh_hads.lua
@@ -2,6 +2,7 @@
 
 if SERVER then
     function ENT:SetHADS(on)
+        self:CallCommonHook("HadsToggled", on)
         return self:SetData("hads",on,true)
     end
 

--- a/lua/entities/gmod_tardis/modules/sh_health.lua
+++ b/lua/entities/gmod_tardis/modules/sh_health.lua
@@ -88,12 +88,14 @@ if SERVER then
             return false
         end
         if self:CallHook("CanRepair")==false then return false end
-        if on==true then
+        if on == true then
             for k,_ in pairs(self.occupants) do
                 TARDIS:Message(k, "Health.RepairActivated")
             end
-            if self:GetPower() then self:SetPower(false) end
-            self:SetData("repair-primed",true,true)
+            local power = self:GetPower()
+            self:SetData("power-before-repair", power)
+            if power then self:SetPower(false) end
+            self:SetData("repair-primed", true, true)
 
             if table.IsEmpty(self.occupants) then
                 self:Timer("repair-nooccupants", 0, function() 
@@ -103,11 +105,19 @@ if SERVER then
             end
         else
             self:SetData("repair-primed",false,true)
-            self:SetPower(true)
+
+            local prev_power = self:GetData("power-before-repair")
+            if (prev_power ~= nil) then
+                self:SetPower(prev_power)
+            else
+                self:SetPower(true)
+            end
+
             for k,_ in pairs(self.occupants) do
                 TARDIS:Message(k, "Health.RepairCancelled")
             end
         end
+        self:CallHook("RepairToggled", on)
         return true
     end
 

--- a/lua/entities/gmod_tardis/modules/sh_lock.lua
+++ b/lua/entities/gmod_tardis/modules/sh_lock.lua
@@ -18,7 +18,7 @@ if SERVER then
         self:SetData("locked",locked,true)
         self:FlashLight(0.6)
         if not silent then self:SendMessage("locksound") end
-        self:CallHook("DoorLockToggled", current)
+        self:CallHook("DoorLockToggled", locked)
         if callback then callback(true) end
     end
 

--- a/lua/entities/gmod_tardis/modules/sh_lock.lua
+++ b/lua/entities/gmod_tardis/modules/sh_lock.lua
@@ -18,6 +18,7 @@ if SERVER then
         self:SetData("locked",locked,true)
         self:FlashLight(0.6)
         if not silent then self:SendMessage("locksound") end
+        self:CallHook("DoorLockToggled", current)
         if callback then callback(true) end
     end
 

--- a/lua/entities/gmod_tardis/modules/sh_physlock.lua
+++ b/lua/entities/gmod_tardis/modules/sh_physlock.lua
@@ -45,6 +45,7 @@ function ENT:SetPhyslock(on)
         phys:EnableMotion(true)
     end
     phys:Wake()
+    self:CallCommonHook("PhyslockToggled", on)
     return true
 end
 

--- a/lua/entities/gmod_tardis/modules/sh_security.lua
+++ b/lua/entities/gmod_tardis/modules/sh_security.lua
@@ -10,6 +10,7 @@ end
 
 if SERVER then
     function ENT:SetSecurity(on)
+        self:CallHook("SecurityToggled", on)
         return self:SetData("security", on, true)
     end
 

--- a/lua/entities/gmod_tardis/modules/sh_spin.lua
+++ b/lua/entities/gmod_tardis/modules/sh_spin.lua
@@ -28,12 +28,17 @@ if SERVER then
         self:SetData("spindir_prev", 0, true)
     end)
 
+    function ENT:SetSpinDir(dir)
+        self:CallHook("SpinChanged", dir)
+        return self:SetData("spindir", dir, true)
+    end
+
     function ENT:ToggleSpin()
         local current = self:GetData("spindir", -1)
         local prev = self:GetData("spindir_prev", 0)
 
         self:SetData("spindir_prev", current, true)
-        self:SetData("spindir", prev, true)
+        self:SetSpinDir(prev)
     end
 
     function ENT:CycleSpinDir()
@@ -41,7 +46,7 @@ if SERVER then
         local prev = self:GetData("spindir_prev", 0)
 
         self:SetData("spindir_prev", current, true)
-        self:SetData("spindir", -prev, true)
+        self:SetSpinDir(-prev)
     end
 
     function ENT:SwitchSpinDir()
@@ -49,11 +54,7 @@ if SERVER then
         local prev = self:GetData("spindir_prev", 0)
 
         self:SetData("spindir_prev", -prev, true)
-        self:SetData("spindir", -current, true)
-    end
-
-    function ENT:SetSpinDir(dir)
-        return self:SetData("spindir", dir, true)
+        self:SetSpinDir(-current)
     end
 
     ENT:AddHook("ToggleDoorReal", "spin-dir", function(self,open)

--- a/lua/entities/gmod_tardis/modules/teleport/sh_tp_main.lua
+++ b/lua/entities/gmod_tardis/modules/teleport/sh_tp_main.lua
@@ -62,7 +62,7 @@ if SERVER then
     function ENT:SetRandomDestination(grounded)
         local randomLocation = self:GetRandomLocation(grounded)
         if randomLocation then
-            self:CallHook("RandomDestinationSet")
+            self:CallHook("RandomDestinationSet", randomLocation)
             self:SetDestination(randomLocation, Angle(0,0,0))
             return true
         else

--- a/lua/entities/gmod_tardis/modules/teleport/sh_tp_main.lua
+++ b/lua/entities/gmod_tardis/modules/teleport/sh_tp_main.lua
@@ -62,6 +62,7 @@ if SERVER then
     function ENT:SetRandomDestination(grounded)
         local randomLocation = self:GetRandomLocation(grounded)
         if randomLocation then
+            self:CallHook("RandomDestinationSet")
             self:SetDestination(randomLocation, Angle(0,0,0))
             return true
         else
@@ -213,6 +214,7 @@ if SERVER then
 
             self:SendMessage("premat",function() net.WriteVector(self:GetData("demat-pos",Vector())) end)
             self:SetData("teleport",true)
+            self:CallHook("PreMatStart")
 
             local timerdelay = (self:GetData("demat-fast",false) and 1.9 or 8.5)
             self:Timer("matdelay", timerdelay, function()
@@ -376,6 +378,7 @@ else
                 end
             end
         end
+        self:CallHook("DematStart")
     end)
 
     ENT:OnMessage("premat", function(self)
@@ -411,12 +414,14 @@ else
                 end
             end
         end
+        self:CallHook("PreMatStart")
     end)
 
     ENT:OnMessage("mat", function(self)
         self:SetData("mat",true)
         self:SetData("step",1)
         self:SetData("vortex",false)
+        self:CallHook("MatStart")
     end)
 
     function ENT:StopDemat()
@@ -431,6 +436,7 @@ else
         self:SetData("mat",false)
         self:SetData("step",1)
         self:SetData("teleport",false)
+        self:CallHook("StopMat")
     end
 
 end

--- a/lua/entities/gmod_tardis/modules/teleport/sh_tp_vortex.lua
+++ b/lua/entities/gmod_tardis/modules/teleport/sh_tp_vortex.lua
@@ -35,7 +35,7 @@ function ENT:FastReturn(callback)
         self:SetData("demat-fast-prev", self:GetData("demat-fast", false));
         self:SetFastRemat(true)
         self:SetData("fastreturn",true)
-        self:CallHook("FastReturnTriggered", current)
+        self:CallHook("FastReturnTriggered")
         self:Demat(self:GetData("fastreturn-pos"),self:GetData("fastreturn-ang"))
         if callback then callback(true) end
     else

--- a/lua/entities/gmod_tardis/modules/teleport/sh_tp_vortex.lua
+++ b/lua/entities/gmod_tardis/modules/teleport/sh_tp_vortex.lua
@@ -20,6 +20,7 @@ end
 
 function ENT:SetFastRemat(on)
     self:SetData("demat-fast",on,true)
+    self:CallHook("FastRematToggled", on)
     return true
 end
 
@@ -34,6 +35,7 @@ function ENT:FastReturn(callback)
         self:SetData("demat-fast-prev", self:GetData("demat-fast", false));
         self:SetFastRemat(true)
         self:SetData("fastreturn",true)
+        self:CallHook("FastReturnTriggered", current)
         self:Demat(self:GetData("fastreturn-pos"),self:GetData("fastreturn-ang"))
         if callback then callback(true) end
     else

--- a/lua/entities/gmod_tardis_interior/modules/sh_scanner.lua
+++ b/lua/entities/gmod_tardis_interior/modules/sh_scanner.lua
@@ -7,6 +7,7 @@ end
 if SERVER then
     function ENT:SetScannersOn(on)
         self:SetData("scanners_on", on, true)
+        self:CallHook("ScannersToggled", on)
         return true
     end
 

--- a/lua/tardis/controls/sh_control_redecorate.lua
+++ b/lua/tardis/controls/sh_control_redecorate.lua
@@ -8,6 +8,7 @@ TARDIS:AddControl({
 
         local on = not self:GetData("redecorate", false)
         self:SetData("redecorate", on, true)
+        self:CallHook("RedecorateToggled", on)
         TARDIS:StatusMessage(ply, "Controls.Redecorate.Status", on)
 
         if not self:GetData("redecorate", false) then


### PR DESCRIPTION
Multiple of these changes are currently required for making extension updates (to avoid calling `DataChanged` hooks any further)
Others have potential to being required

**Changes:**
- added a bunch of new hooks
- added some teleport-related hooks to be called clientside (for texture-related changes)
- made self-repair restore the previous power value instead of turning it on
- minor spin functions refactoring

**Added Hooks:**
RandomDestinationSet
PreMatStart
FastRematToggled
FastReturnTriggered
CloakToggled
FlightToggled
FloatToggled
HadsToggled
RepairToggled
DoorLockToggled
PhyslockToggled
SecurityToggled
SpinChanged
ScannersToggled
RedecorateToggled

**Clientside hooks added (for texture changes etc.):**
DematStart
PreMatStart
MatStart
StopMat
