### PR TITLE
Add sprite feature to lamps

### DIFF
--- a/lua/entities/gmod_tardis_interior/modules/sh_interior_lights.lua
+++ b/lua/entities/gmod_tardis_interior/modules/sh_interior_lights.lua
@@ -362,7 +362,7 @@ if CLIENT then
             local data = SelectLampTable(self, v)
             if not data then return end
             if data.sprite then
-                -- taken from https://github.com/Facepunch/garrysmod/blob/master/garrysmod/gamemodes/sandbox/entities/entities/gmod_lamp.lua
+                -- adapted from https://github.com/Facepunch/garrysmod/blob/master/garrysmod/gamemodes/sandbox/entities/entities/gmod_lamp.lua
 
                 local lightPos = data.pos_global
                 local viewNormal = lightPos - EyePos()

--- a/lua/entities/gmod_tardis_interior/modules/sh_interior_lights.lua
+++ b/lua/entities/gmod_tardis_interior/modules/sh_interior_lights.lua
@@ -353,7 +353,7 @@ if CLIENT then
         end
     end)
 
-    local matLight = Material( "sprites/light_ignorez" )
+    local matLight = Material("sprites/light_ignorez")
     ENT:AddHook("Draw", "lamps", function(self)
         if not TARDIS:GetSetting("lamps-enabled") then return end
         if not self.lamps_data then return end

--- a/lua/entities/gmod_tardis_interior/modules/sh_interior_lights.lua
+++ b/lua/entities/gmod_tardis_interior/modules/sh_interior_lights.lua
@@ -362,23 +362,23 @@ if CLIENT then
             local data = SelectLampTable(self, v)
             if not data then return end
             if data.sprite then
-                -- inspired by https://github.com/Facepunch/garrysmod/blob/master/garrysmod/gamemodes/sandbox/entities/entities/gmod_lamp.lua
+                -- taken from https://github.com/Facepunch/garrysmod/blob/master/garrysmod/gamemodes/sandbox/entities/entities/gmod_lamp.lua
 
                 local lightPos = data.pos_global
                 local viewNormal = lightPos - EyePos()
                 local distance = viewNormal:Length()
 
                 render.SetMaterial( matLight )
-                local visible = util.PixelVisible( lightPos, 16, data.spritepixvis )
-                if ( not visible ) then return end
+                local visible = util.PixelVisible(lightPos, 16, data.spritepixvis)
+                if not visible then return end
 
-                local size = math.Clamp( distance * visible * 2, 64, 512 )
+                local size = math.Clamp(distance * visible * 2, 64, 512)
 
-                distance = math.Clamp( distance, 32, 800 )
-                local alpha = math.Clamp( ( 1000 - distance ) * visible * data.sprite_brightness, 0, 100 )
+                distance = math.Clamp(distance, 32, 800)
+                local alpha = math.Clamp((1000 - distance) * visible * data.sprite_brightness, 0, 100)
 
-                render.DrawSprite( lightPos, size, size, ColorAlpha(data.color, alpha) )
-                render.DrawSprite( lightPos, size * 0.4, size * 0.4, Color( 255, 255, 255, alpha ) )
+                render.DrawSprite(lightPos, size, size, ColorAlpha(data.color, alpha))
+                render.DrawSprite(lightPos, size * 0.4, size * 0.4, Color( 255, 255, 255, alpha ))
             end
         end
     end)

--- a/lua/entities/gmod_tardis_interior/modules/sh_interior_lights.lua
+++ b/lua/entities/gmod_tardis_interior/modules/sh_interior_lights.lua
@@ -219,6 +219,10 @@ if CLIENT then
     function ENT:InitLampData(lmp)
         if not lmp or not lmp.pos then return end
         lmp.pos_global = self:LocalToWorld(lmp.pos)
+        if lmp.sprite then
+            lmp.spritepixvis = util.GetPixelVisibleHandle()
+            lmp.sprite_brightness = lmp.sprite_brightness or 1
+        end
         self:InitLampData(lmp.warn)
         self:InitLampData(lmp.off)
         self:InitLampData(lmp.off_warn)
@@ -349,6 +353,35 @@ if CLIENT then
         end
     end)
 
+    local matLight = Material( "sprites/light_ignorez" )
+    ENT:AddHook("Draw", "lamps", function(self)
+        if not TARDIS:GetSetting("lamps-enabled") then return end
+        if not self.lamps_data then return end
+
+        for k,v in pairs(self.lamps_data) do
+            local data = SelectLampTable(self, v)
+            if not data then return end
+            if data.sprite then
+                -- inspired by https://github.com/Facepunch/garrysmod/blob/master/garrysmod/gamemodes/sandbox/entities/entities/gmod_lamp.lua
+
+                local lightPos = data.pos_global
+                local viewNormal = lightPos - EyePos()
+                local distance = viewNormal:Length()
+
+                render.SetMaterial( matLight )
+                local visible = util.PixelVisible( lightPos, 16, data.spritepixvis )
+                if ( not visible ) then return end
+
+                local size = math.Clamp( distance * visible * 2, 64, 512 )
+
+                distance = math.Clamp( distance, 32, 800 )
+                local alpha = math.Clamp( ( 1000 - distance ) * visible * data.sprite_brightness, 0, 100 )
+
+                render.DrawSprite( lightPos, size, size, ColorAlpha(data.color, alpha) )
+                render.DrawSprite( lightPos, size * 0.4, size * 0.4, Color( 255, 255, 255, alpha ) )
+            end
+        end
+    end)
 
 
     ENT:AddHook("SettingChanged", "lamps", function(self, id, val)


### PR DESCRIPTION
Adds two new properties on lamps, `sprite` (bool) and `sprite_brightness` (0 - 1 float) which can show a sprite just like the default GMod lamp on the lamps when enabled

Example:
![image](https://user-images.githubusercontent.com/2363642/217354870-81210ce5-47f4-4e43-842e-8f04ad57f971.png)
