### PR TITLE
Rudimentary Life Support

### DIFF
--- a/lua/entities/gmod_tardis_interior/init.lua
+++ b/lua/entities/gmod_tardis_interior/init.lua
@@ -24,9 +24,46 @@ function ENT:Initialize()
         self.ExitDistance=self.metadata.Interior.ExitDistance
     end
     self.BaseClass.Initialize(self)
+
+    if(#file.Find("weapons/gmod_tool/environments_tool_base.lua","LUA") == 1 or #file.Find("weapons/gmod_tool/stools/dev_link.lua","LUA") == 1 or #file.Find("weapons/gmod_tool/stools/rd3_dev_link.lua","LUA") == 1) then
+		self.HasResourceDistribution = true;
+	else
+		self.HasResourceDistribution = false;
+	end
 end
 
 function ENT:OnTakeDamage(dmginfo)
     if self:CallHook("ShouldTakeDamage",dmginfo)==false then return end
     self:CallHook("OnTakeDamage", dmginfo)
+end
+
+function ENT:Think()
+    if(self.HasResourceDistribution) then
+		self:LSSupport()
+	end
+end
+
+--####### Give us air @RononDex (Modified by Jeppe)
+function ENT:LSSupport()
+
+	local ent_pos = self:GetPos();
+
+	if(IsValid(self)) then
+		for _,p in pairs(player.GetAll()) do -- Find all players
+			local pos = (p:GetPos()-ent_pos):Length(); -- Where they are in relation to the interior
+			if(pos<410 and p.suit) then -- If they're close enough
+                print("close nuff")
+				if(not(CAF and CAF.GetAddon("Resource Distribution"))) then
+					if (p.suit.air<100) then p.suit.air = 100; end -- They get air
+					if (p.suit.energy<100) then p.suit.energy = 100; end -- and energy
+					if (p.suit.coolant<100) then p.suit.coolant = 100; end -- and coolant
+				else
+					-- We need double the amount of LS3(No idea why)
+					if (p.suit.air<200) then p.suit.air = 200; end -- They get air
+					if (p.suit.energy<200) then p.suit.energy = 200; end -- and energy
+					if (p.suit.coolant<200) then p.suit.coolant = 200; end -- and coolant
+				end
+			end
+		end
+	end
 end

--- a/lua/entities/gmod_tardis_interior/init.lua
+++ b/lua/entities/gmod_tardis_interior/init.lua
@@ -51,8 +51,7 @@ function ENT:LSSupport()
 	if(IsValid(self)) then
 		for _,p in pairs(player.GetAll()) do -- Find all players
 			local pos = (p:GetPos()-ent_pos):Length(); -- Where they are in relation to the interior
-			if(pos<410 and p.suit) then -- If they're close enough
-                print("close nuff")
+			if(pos<500 and p.suit) then -- If they're close enough
 				if(not(CAF and CAF.GetAddon("Resource Distribution"))) then
 					if (p.suit.air<100) then p.suit.air = 100; end -- They get air
 					if (p.suit.energy<100) then p.suit.energy = 100; end -- and energy


### PR DESCRIPTION
This is a small update that will prevent players from suffucating in the TARDIS when Spacebuild is enabled.

It won't create artificial gravity or an atmosphere, but it can serve as a temporary solution until #28 can be properly implemented.