### PR TITLE
Changed setting name

### DIFF
--- a/lua/tardis/settings/cl_gui.lua
+++ b/lua/tardis/settings/cl_gui.lua
@@ -70,7 +70,7 @@ TARDIS:AddSetting({
 })
 
 TARDIS:AddSetting({
-    id = "visgui_theme",
+    id = "visgui_interface_theme",
     type = "list",
     value = "default_interior",
 

--- a/lua/tardis/sh_visgui_themes.lua
+++ b/lua/tardis/sh_visgui_themes.lua
@@ -12,7 +12,7 @@ end
 TARDIS:LoadFolder("themes/visgui", nil, true)
 
 function TARDIS:GetScreenGUITheme(screen)
-    local setting = TARDIS:GetSetting("visgui_theme")
+    local setting = TARDIS:GetSetting("visgui_interface_theme")
     if setting ~= "default_interior" then
         return setting
     end


### PR DESCRIPTION
**Why I think this is required:** the setting has been there for ages, and for all the current users, it will exist before it updates; consequently, the majority of players will have the default theme for all TARDISes.

I doubt anyone had been using it actually...

If this setting is named differently, for most people it will be set to the new default aka "set by interior" and interior themes will be supported for everyone without everything breaking