### PR TITLE
Make E2 Functions also move the console controls

### DIFF
--- a/lua/entities/gmod_tardis/modules/sh_cloak.lua
+++ b/lua/entities/gmod_tardis/modules/sh_cloak.lua
@@ -42,7 +42,7 @@ if SERVER then
         self:CallHook("CloakToggled", on)
         return true
     end
-    
+
     function ENT:ToggleCloak()
         local on = not self:GetData("cloak", false)
         return self:SetCloak(on)
@@ -50,6 +50,10 @@ if SERVER then
 
     ENT:AddHook("HandleE2", "cloak", function(self,name,e2)
         if name == "Phase" and TARDIS:CheckPP(e2.player, self) then
+            local part = TARDIS:GetPartByAction(self.interior, "cloak")
+            if part ~= nil then
+                TARDIS:UsePart(part)
+            end
             return (self:GetPower() and self:ToggleCloak()) and 1 or 0
         elseif name == "GetVisible" then
             return self:GetData("cloak",false) and 0 or 1

--- a/lua/entities/gmod_tardis/modules/sh_doors.lua
+++ b/lua/entities/gmod_tardis/modules/sh_doors.lua
@@ -88,6 +88,10 @@ if SERVER then
 
     ENT:AddHook("HandleE2", "door", function(self,name,e2)
         if name == "Door" and TARDIS:CheckPP(e2.player, self) then
+            local part = TARDIS:GetPartByAction(self.interior, "door")
+            if part ~= nil then
+                TARDIS:UsePart(part)
+            end
             return self:ToggleDoor() and 1 or 0
         elseif name == "GetDoor" then
             return self:DoorOpen(true) and 1 or 0

--- a/lua/entities/gmod_tardis/modules/sh_flight.lua
+++ b/lua/entities/gmod_tardis/modules/sh_flight.lua
@@ -332,6 +332,10 @@ if SERVER then
     ENT:AddHook("HandleE2", "flight", function(self, name, e2, ...)
         local args = {...}
         if name == "Flightmode" and TARDIS:CheckPP(e2.player, self) then
+            local part = TARDIS:GetPartByAction(self.interior, "flight")
+            if part ~= nil then
+                TARDIS:UsePart(part)
+            end
             local on = args[1]
             if on then
                 return self:SetFlight(on) and 1 or 0
@@ -339,6 +343,10 @@ if SERVER then
                 return self:ToggleFlight() and 1 or 0
             end
         elseif name == "Spinmode" and TARDIS:CheckPP(e2.player, self) then
+            local part = TARDIS:GetPartByAction(self.interior, "spin_switch")
+            if part ~= nil then
+                TARDIS:UsePart(part)
+            end
             local spindir = args[1]
             self:SetSpinDir(spindir)
             return self:GetSpinDir()

--- a/lua/entities/gmod_tardis/modules/sh_hads.lua
+++ b/lua/entities/gmod_tardis/modules/sh_hads.lua
@@ -98,6 +98,10 @@ if SERVER then
         if name == "GetHADS" then
             return self:GetData("hads",false) and 1 or 0
         elseif name == "HADS" and TARDIS:CheckPP(e2.player, self) then
+            local part = TARDIS:GetPartByAction(self.interior, "hads")
+            if part ~= nil then
+                TARDIS:UsePart(part)
+            end
             return self:ToggleHADS()
         end
     end)

--- a/lua/entities/gmod_tardis/modules/sh_health.lua
+++ b/lua/entities/gmod_tardis/modules/sh_health.lua
@@ -345,6 +345,10 @@ if SERVER then
         if name == "GetHealth" then
             return self:GetHealthPercent()
         elseif name == "Selfrepair" and TARDIS:CheckPP(e2.player, self) then
+            local part = TARDIS:GetPartByAction(self.interior, "repair")
+            if part ~= nil then
+                TARDIS:UsePart(part)
+            end
             self:ToggleRepair()
             return self:GetData("repair-primed",false) and 1 or 0
         elseif name == "GetSelfrepairing" then

--- a/lua/entities/gmod_tardis/modules/sh_lock.lua
+++ b/lua/entities/gmod_tardis/modules/sh_lock.lua
@@ -78,6 +78,10 @@ if SERVER then
                 return 0
             end
         elseif name == "Lock" and TARDIS:CheckPP(e2.player, self) then
+            local part = TARDIS:GetPartByAction(self.interior, "doorlock")
+            if part ~= nil then
+                TARDIS:UsePart(part)
+            end
             return self:ToggleLocked() and 1 or 0
         end
     end)

--- a/lua/entities/gmod_tardis/modules/sh_physlock.lua
+++ b/lua/entities/gmod_tardis/modules/sh_physlock.lua
@@ -100,6 +100,10 @@ ENT:AddHook("HandleE2", "physlock", function(self, name, e2)
     if name == "GetPhyslocked" then
         return self:GetPhyslock() and 1 or 0
     elseif name == "Physlock" and TARDIS:CheckPP(e2.player, self) then
+        local part = TARDIS:GetPartByAction(self.interior, "physlock")
+        if part ~= nil then
+            TARDIS:UsePart(part)
+        end
         return self:TogglePhyslock() and 1 or 0
     end
 end)

--- a/lua/entities/gmod_tardis/modules/sh_power.lua
+++ b/lua/entities/gmod_tardis/modules/sh_power.lua
@@ -52,6 +52,10 @@ if SERVER then
 
     ENT:AddHook("HandleE2", "power", function(self,name,e2)
         if name == "Power" and TARDIS:CheckPP(e2.player, self) then
+            local part = TARDIS:GetPartByAction(self.interior, "power")
+            if part ~= nil then
+                TARDIS:UsePart(part)
+            end
             return self:TogglePower() and 1 or 0
         elseif name == "GetPowered" then
             return self:GetPower() and 1 or 0

--- a/lua/entities/gmod_tardis/modules/sh_security.lua
+++ b/lua/entities/gmod_tardis/modules/sh_security.lua
@@ -51,6 +51,10 @@ end)
 ENT:AddHook("HandleE2", "security", function(self,name,e2)
     if IsValid(self.interior) then
         if name == "Isomorph" and TARDIS:CheckPP(e2.player, self) then
+            local part = TARDIS:GetPartByAction(self.interior, "isomorphic")
+            if part ~= nil then
+                TARDIS:UsePart(part)
+            end
             return self.interior:ToggleSecurity() and 1 or 0
         elseif name == "GetIsomorphic" then
             return self.interior:GetSecurity() and 1 or 0

--- a/lua/entities/gmod_tardis/modules/teleport/sv_tp_wiremod_e2.lua
+++ b/lua/entities/gmod_tardis/modules/teleport/sv_tp_wiremod_e2.lua
@@ -22,6 +22,14 @@ end)
 ENT:AddHook("HandleE2", "teleport_args", function(self, name, e2, pos, ang)
     if name == "Demat" and TARDIS:CheckPP(e2.player, self) then
         local success = self:CallHook("CanDemat")==false
+        local part = TARDIS:GetPartByAction(self.interior, "teleport")
+        if part ~= nil then
+            TARDIS:UsePart(part)
+        end
+        local part = TARDIS:GetPartByAction(self.interior, "teleport_double")
+        if part ~= nil then
+            TARDIS:UsePart(part)
+        end
         if not pos or not ang then
             self:Demat()
         else
@@ -37,16 +45,37 @@ end)
 
 ENT:AddHook("HandleE2", "teleport_noargs", function(self, name, e2)
     if name == "Mat" and TARDIS:CheckPP(e2.player, self) then
+        local part = TARDIS:GetPartByAction(self.interior, "teleport")
+        if part ~= nil then
+            TARDIS:UsePart(part)
+        end
+        local part = TARDIS:GetPartByAction(self.interior, "teleport_double")
+        if part ~= nil then
+            TARDIS:UsePart(part)
+        end
         local success = (self:GetData("vortex",false) and self:CallHook("CanMat"))==false
         self:Mat()
         return success and 0 or 1
     elseif name == "Longflight" and TARDIS:CheckPP(e2.player, self) then
         return self:ToggleFastRemat() and 1 or 0
     elseif name == "FastReturn" and TARDIS:CheckPP(e2.player, self) then
+        local part = TARDIS:GetPartByAction(self.interior, "fastreturn")
+        if part ~= nil then
+            TARDIS:UsePart(part)
+        end
         local success = self:CallHook("CanDemat")==false
         self:FastReturn()
         return success and 0 or 1
-    elseif name == "FastDemat" and TARDIS:CheckPP(e2.player, self)then
+    elseif name == "FastDemat" and TARDIS:CheckPP(e2.player, self) then
+        local success = self:CallHook("CanDemat")==false
+        local part = TARDIS:GetPartByAction(self.interior, "teleport")
+        if part ~= nil then
+            TARDIS:UsePart(part)
+        end
+        local part = TARDIS:GetPartByAction(self.interior, "teleport_double")
+        if part ~= nil then
+            TARDIS:UsePart(part)
+        end
         local success = self:CallHook("CanDemat")==false
         self:Demat()
         return success and 0 or 1

--- a/lua/entities/gmod_wire_expression2/core/custom/tardis2.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/tardis2.lua
@@ -21,13 +21,6 @@ local function HandleE2(ent, type, name, e2, ...)
         if type == "Setter" and ent:CheckSecurity(e2.player) == false then
             TARDIS:ErrorMessage(e2.player,"Expression2.Security.UseDenied")
         else
-            if type == "Setter" and name == "Phase" then
-                local ply = ent:GetCreator()
-                --local part = TARDIS:GetPart(ent.interior, "default_blacksticks")
-                local part = TARDIS:GetRegisteredPart("hads")
-                tardisdebug(part.source)
-                TARDIS:UsePart(part)
-            end
             return ent:HandleE2(name, e2, ...)
         end
     else

--- a/lua/entities/gmod_wire_expression2/core/custom/tardis2.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/tardis2.lua
@@ -21,6 +21,13 @@ local function HandleE2(ent, type, name, e2, ...)
         if type == "Setter" and ent:CheckSecurity(e2.player) == false then
             TARDIS:ErrorMessage(e2.player,"Expression2.Security.UseDenied")
         else
+            if type == "Setter" and name == "Phase" then
+                local ply = ent:GetCreator()
+                --local part = TARDIS:GetPart(ent.interior, "default_blacksticks")
+                local part = TARDIS:GetRegisteredPart("hads")
+                tardisdebug(part.source)
+                TARDIS:UsePart(part)
+            end
             return ent:HandleE2(name, e2, ...)
         end
     else

--- a/lua/tardis/sh_parts.lua
+++ b/lua/tardis/sh_parts.lua
@@ -39,6 +39,27 @@ function TARDIS.DrawOverride(self,override)
     end
 end
 
+function TARDIS:UsePart(part)
+    if part.PowerOffSound ~= false or part.interior:GetPower() then
+        local part_sound = nil
+
+        if part.SoundOff and on then
+            part_sound = part.SoundOff
+        elseif part.SoundOn and (not on) then
+            part_sound = part.SoundOn
+        elseif part.Sound then
+            part_sound = part.Sound
+        end
+
+        if part_sound and part.SoundPos then
+            sound.Play(part_sound, part:LocalToWorld(part.SoundPos))
+        elseif part_sound then
+            part:EmitSound(part_sound)
+        end
+    end
+    part:SetOn(not part:GetOn())
+end
+
 local overrides={
     ["Draw"]={TARDIS.DrawOverride, CLIENT},
     ["Initialize"]={function(self)
@@ -158,6 +179,15 @@ end
 
 function TARDIS:GetParts(ent)
     return IsValid(ent) and ent.parts
+end
+
+function TARDIS:GetPartByAction(ent, action)
+    -- Looks through the parts, and returns the ID of the part that does the action
+    for k,v in pairs(ent.metadata.Interior.Controls) do
+        if v == action then
+            return ent.parts[k]
+        end
+    end
 end
 
 local overridequeue={}


### PR DESCRIPTION
Added a new function called `TARDIS:UsePart`, when called, it plays the control animation alongside the sound. Added `UsePart` to the `HandleE2` events.