### PR TITLE
Fullflight seprate delay

### DIFF
--- a/lua/entities/gmod_tardis/modules/teleport/sh_tp_main.lua
+++ b/lua/entities/gmod_tardis/modules/teleport/sh_tp_main.lua
@@ -368,23 +368,23 @@ end
 
 function ENT:SetStepDelay()
     local demat=self:GetData("demat")
-    local full=self:GetFastRemat()
+    local fast=self:GetFastRemat()
     local mat=self:GetData("mat")
     if not (demat or mat) then return end
 
     local teleport_md = self.metadata.Exterior.Teleport
     local sequence_delays
     if demat then
-        if not full then
-            sequence_delays = teleport_md.DematSequenceDelays
-        else
+        if fast then
             sequence_delays = teleport_md.DematFastSequenceDelays
+        else
+            sequence_delays = teleport_md.DematSequenceDelays
         end
     else
-        if not full then
-            sequence_delays = teleport_md.MatSequenceDelays
-        else
+        if fast then
             sequence_delays = teleport_md.MatFastSequenceDelays
+        else
+            sequence_delays = teleport_md.MatSequenceDelays
         end
     end
     local step = self:GetData("step",1)

--- a/lua/entities/gmod_tardis/modules/teleport/sh_tp_main.lua
+++ b/lua/entities/gmod_tardis/modules/teleport/sh_tp_main.lua
@@ -368,15 +368,24 @@ end
 
 function ENT:SetStepDelay()
     local demat=self:GetData("demat")
+    local full=self:GetFastRemat()
     local mat=self:GetData("mat")
     if not (demat or mat) then return end
 
     local teleport_md = self.metadata.Exterior.Teleport
     local sequence_delays
     if demat then
-        sequence_delays = teleport_md.DematSequenceDelays
+        if not full then
+            sequence_delays = teleport_md.DematSequenceDelays
+        else
+            sequence_delays = teleport_md.DematFastSequenceDelays
+        end
     else
-        sequence_delays = teleport_md.MatSequenceDelays
+        if not full then
+            sequence_delays = teleport_md.MatSequenceDelays
+        else
+            sequence_delays = teleport_md.MatFastSequenceDelays
+        end
     end
     local step = self:GetData("step",1)
     if sequence_delays and sequence_delays[step] then


### PR DESCRIPTION
Speaks for itself. The time for demat delay doesnt compensate for mat delay so this feature is just necessary for people who use the delay feature(me)