### PR TITLE
Add ExitBox and Size capabilities

### DIFF
--- a/lua/entities/gmod_tardis/modules/sh_aprilfools.lua
+++ b/lua/entities/gmod_tardis/modules/sh_aprilfools.lua
@@ -53,12 +53,13 @@ ENT:AddHook("Think", "april_fools", function(self,delta)
     end
 end)
 
-local mat = Material("models/drmatt/tardis/black")
+local mat = Material("models/drmatt/tardis/exterior/black")
 hook.Add("PostDrawOpaqueRenderables", "tardis-aprilfools", function()
     if not TARDIS:IsAprilFools() or wp.drawing then return end
     local ext=TARDIS:GetExteriorEnt()
     if IsValid(ext) and IsValid(ext.interior) and (ext:GetData("teleport",false) or ext:GetData("vortex",false)) and (not ext.interior.scannerrender) and (not LocalPlayer():GetTardisData("outside")) then
         render.SetMaterial(mat)
-        render.DrawSphere(ext.interior:GetPos(), -ext.metadata.Interior.ExitDistance * 1.5, 50, 50)
+        local center,radius=ext.interior:GetSphere()
+        render.DrawSphere(ext.interior:LocalToWorld(center), -radius * 1.5, 50, 50)
     end
 end)

--- a/lua/entities/gmod_tardis_debug_pointer/cl_init.lua
+++ b/lua/entities/gmod_tardis_debug_pointer/cl_init.lua
@@ -3,6 +3,34 @@
 
 include('shared.lua')
 
+function ENT:Initialize()
+    self:UpdateRenderBounds()
+end
+
 function ENT:Draw()
     self:DrawModel()
+
+    if self:GetDrawAABox() then
+        local other = self:GetOther()
+        if not IsValid(other) then return end
+        local mins, maxs = self:GetRenderBounds()
+        render.DrawWireframeBox(self:GetPos(), angle_zero, vector_origin, other:GetPos() - self:GetPos(), Color(255, 0, 0), true)
+    end
+end
+
+function ENT:UpdateRenderBounds()
+    local other = self:GetOther()
+    if IsValid(other) then
+        local mins, maxs = self:GetPos(), self:GetOther():GetPos()
+        self:SetRenderBoundsWS(mins, maxs)
+    else
+        self:SetRenderBounds(self:OBBMins(), self:OBBMaxs())
+    end
+
+end
+
+function ENT:Think()
+    if self:GetDrawAABox() then
+        self:UpdateRenderBounds()
+    end
 end

--- a/lua/entities/gmod_tardis_debug_pointer/cl_init.lua
+++ b/lua/entities/gmod_tardis_debug_pointer/cl_init.lua
@@ -26,7 +26,6 @@ function ENT:UpdateRenderBounds()
     else
         self:SetRenderBounds(self:OBBMins(), self:OBBMaxs())
     end
-
 end
 
 function ENT:Think()

--- a/lua/entities/gmod_tardis_debug_pointer/shared.lua
+++ b/lua/entities/gmod_tardis_debug_pointer/shared.lua
@@ -82,7 +82,15 @@ concommand.Add("tardis2_debug_pointer", function(ply,cmd,args)
     ply:AddCleanup("sents",ent)
 end)
 
+function ENT:SetupDataTables()
+    self:NetworkVar( "Entity", 0, "Other" )
+    self:NetworkVar( "Bool", 0, "DrawAABox" )
 
+    if CLIENT then
+        self:NetworkVarNotify( "DrawAABox", self.UpdateRenderBounds )
+        self:NetworkVarNotify( "Other", self.UpdateRenderBounds )
+    end
+end
 
 if SERVER then
     util.AddNetworkString("TARDIS-Pointer-Debug")

--- a/lua/entities/gmod_tardis_debug_pointer/shared.lua
+++ b/lua/entities/gmod_tardis_debug_pointer/shared.lua
@@ -83,12 +83,12 @@ concommand.Add("tardis2_debug_pointer", function(ply,cmd,args)
 end)
 
 function ENT:SetupDataTables()
-    self:NetworkVar( "Entity", 0, "Other" )
-    self:NetworkVar( "Bool", 0, "DrawAABox" )
+    self:NetworkVar("Entity",0,"Other")
+    self:NetworkVar("Bool",0,"DrawAABox")
 
     if CLIENT then
-        self:NetworkVarNotify( "DrawAABox", self.UpdateRenderBounds )
-        self:NetworkVarNotify( "Other", self.UpdateRenderBounds )
+        self:NetworkVarNotify("DrawAABox",self.UpdateRenderBounds)
+        self:NetworkVarNotify("Other",self.UpdateRenderBounds)
     end
 end
 

--- a/lua/entities/gmod_tardis_interior/cl_init.lua
+++ b/lua/entities/gmod_tardis_interior/cl_init.lua
@@ -14,6 +14,12 @@ ENT:AddHook("PlayerInitialize", "interior", function(self)
     self.Model=self.metadata.Interior.Model
     self.Fallback=self.metadata.Interior.Fallback
     self.Portal=self.metadata.Interior.Portal
-    self.ExitDistance=self.metadata.Interior.ExitDistance
+    if self.metadata.Interior.ExitBox then
+        self.ExitBox=self.metadata.Interior.ExitBox
+    else
+        self.ExitDistance=self.metadata.Interior.ExitDistance
+    end
+    self.mins=self.metadata.Interior.Size.Min
+    self.maxs=self.metadata.Interior.Size.Max
 end)
 

--- a/lua/entities/gmod_tardis_interior/init.lua
+++ b/lua/entities/gmod_tardis_interior/init.lua
@@ -68,7 +68,13 @@ function ENT:Initialize()
         self.Fallback=self.metadata.Interior.Fallback
         self.Portal=self.metadata.Interior.Portal
         self.CustomPortals=self.metadata.Interior.CustomPortals
-        self.ExitDistance=self.metadata.Interior.ExitDistance
+        if self.metadata.Interior.ExitBox then
+            self.ExitBox=self.metadata.Interior.ExitBox
+        else
+            self.ExitDistance=self.metadata.Interior.ExitDistance
+        end
+        self.mins=self.metadata.Interior.Size.Min
+        self.maxs=self.metadata.Interior.Size.Max
     end
     self.BaseClass.Initialize(self)
 end

--- a/lua/entities/gmod_tardis_interior/modules/sh_sphere.lua
+++ b/lua/entities/gmod_tardis_interior/modules/sh_sphere.lua
@@ -4,15 +4,15 @@ function ENT:GetSphere()
     return self:GetData("sphere-center", Vector(0, 0, 0)), self:GetData("sphere-radius", 0)
 end
 
-hook.Add("PostDrawTranslucentRenderables", "tardis-sphere", function()
-    for k, v in pairs(ents.FindByClass("gmod_tardis_interior")) do
-        local center,radius = v:GetSphere()
-        if radius then
-            local pos = v:LocalToWorld(center)
-            render.DrawWireframeSphere(pos, radius, 20, 20, Color(255, 255, 255), true)
-        end
-    end
-end)
+-- hook.Add("PostDrawTranslucentRenderables", "tardis-sphere", function()
+--     for k, v in pairs(ents.FindByClass("gmod_tardis_interior")) do
+--         local center,radius = v:GetSphere()
+--         if radius then
+--             local pos = v:LocalToWorld(center)
+--             render.DrawWireframeSphere(pos, radius, 20, 20, Color(255, 255, 255), true)
+--         end
+--     end
+-- end)
 
 if CLIENT then return end
 

--- a/lua/entities/gmod_tardis_interior/modules/sh_sphere.lua
+++ b/lua/entities/gmod_tardis_interior/modules/sh_sphere.lua
@@ -1,0 +1,39 @@
+-- Metadata
+
+function ENT:GetSphere()
+    return self:GetData("sphere-center", Vector(0, 0, 0)), self:GetData("sphere-radius", 0)
+end
+
+hook.Add("PostDrawTranslucentRenderables", "tardis-sphere", function()
+    for k, v in pairs(ents.FindByClass("gmod_tardis_interior")) do
+        local center,radius = v:GetSphere()
+        if radius then
+            local pos = v:LocalToWorld(center)
+            render.DrawWireframeSphere(pos, radius, 20, 20, Color(255, 255, 255), true)
+        end
+    end
+end)
+
+if CLIENT then return end
+
+function ENT:UpdateSphere()
+    if self.ExitDistance then
+        self:SetData("sphere-radius", self.ExitDistance, true)
+        self:SetData("sphere-center", vector_origin, true)
+        return
+    end
+
+    local mins, maxs = self.ExitBox.Min, self.ExitBox.Max
+    local center = (maxs + mins) / 2
+    local dx = maxs.x - center.x
+    local dy = maxs.y - center.y
+    local dz = maxs.z - center.z
+    local radius = math.sqrt(dx^2 + dy^2 + dz^2)
+
+    self:SetData("sphere-radius", radius, true)
+    self:SetData("sphere-center", center, true)
+end
+
+ENT:AddHook("Initialize", "metadata", function(self)
+    self:UpdateSphere()
+end)

--- a/lua/entities/gmod_tardis_interior/modules/sv_spacebuild.lua
+++ b/lua/entities/gmod_tardis_interior/modules/sv_spacebuild.lua
@@ -1,19 +1,19 @@
 -- Spacebuild
 
-ENT:AddHook("Initialize", "spacebuild", function(self)
+ENT:AddHook("PostInitialize", "spacebuild", function(self)
     if not (CAF and CAF.GetAddon("Spacebuild")) then
         return
     end
 
+    local center, radius = self:GetSphere()
     self.spacebuild_env = ents.Create("base_cube_environment")
     self.spacebuild_env:SetModel("models/props_lab/huladoll.mdl")
-    self.spacebuild_env:SetPos(self:GetPos())
+    self.spacebuild_env:SetPos(self:LocalToWorld(center))
     self.spacebuild_env:SetAngles(self:GetAngles())
     self.spacebuild_env:SetRenderMode(RENDERMODE_NONE)
     self.spacebuild_env:Spawn()
     self.spacebuild_env:Activate()
 
-    local radius = self.metadata.Interior.ExitDistance
     self.spacebuild_env:CreateEnvironment(self, radius)
 
     -- override functions on the cube environment to the simpler base ones

--- a/lua/entities/gmod_time_distortion_generator/init.lua
+++ b/lua/entities/gmod_time_distortion_generator/init.lua
@@ -30,7 +30,7 @@ function ENT:Initialize()
         local inNames = {"Activate","Radius"}
         local inTypes = {"NORMAL","NORMAL"}
 
-        WireLib.CreateSpecialInputs( self,inNames,inTypes)
+        WireLib.CreateSpecialInputs(self,inNames,inTypes)
         Wire_CreateOutputs(self,{"Active","Radius","Health"})
 
         Wire_TriggerOutput(self,"Radius",self.Radius)

--- a/lua/entities/gmod_time_distortion_generator/init.lua
+++ b/lua/entities/gmod_time_distortion_generator/init.lua
@@ -158,13 +158,29 @@ function ENT:Think()
         self:TriggerWire("Active",1)
 
         sound.Play("drmatt/tardis/power_on.wav", self:GetPos())
-
+        
+        local int
         for i,v in ipairs(ents.FindByClass("gmod_tardis_interior")) do
-            if v:GetPos():Distance(self:GetPos()) <= v.metadata.Interior.ExitDistance then
-                for occ,_ in pairs(v.occupants) do
-                    TARDIS:ErrorMessage(occ, "TimeDistortionGenerator.Distortions")
+            local size = v.metadata.Interior.Size
+            if size.Min and size.Max then
+                local min = v:LocalToWorld(size.Min)
+                local max = v:LocalToWorld(size.Max)
+                if self:GetPos():WithinAABox(min, max) then
+                    int = v
+                    break
                 end
-                break
+            else
+                local center,radius=v:GetSphere()
+                if v:LocalToWorld(center):Distance(self:GetPos()) <= radius then
+                    int = v
+                    break
+                end
+            end
+        end
+
+        if IsValid(int) and int.occupants then
+            for occ,_ in pairs(int.occupants) do
+                TARDIS:ErrorMessage(occ, "TimeDistortionGenerator.Distortions")
             end
         end
     end

--- a/lua/tardis/interiors/base.lua
+++ b/lua/tardis/interiors/base.lua
@@ -8,6 +8,7 @@ T.ID = "base"
 T.Interior = {
     Model = "models/drmatt/tardis/interior.mdl",
     ExitDistance = 600,
+    Size = {},
     Portal = {
         pos = Vector(-1,-353.5,136),
         ang = Angle(0,90,0),

--- a/lua/tardis/interiors/default.lua
+++ b/lua/tardis/interiors/default.lua
@@ -17,8 +17,17 @@ T.Versions = {
 
 T.Interior = {
 
-    Model="models/molda/toyota_int/interior.mdl",
-    ExitDistance = 1450,
+    Model = "models/molda/toyota_int/interior.mdl",
+
+    Size = {
+        Min = Vector(-585.336, -1378.008, -33.179),
+        Max = Vector(892.477, 457.64, 381.653)
+    },
+    
+    ExitBox = {
+        Min = Vector(-659.914, -1364.271, -104.82),
+        Max = Vector(984.983, 514.944, 385.095)
+    },
 
     LightOverride = {
         basebrightness = 0.05,

--- a/lua/tardis/libraries/libraries/sh_debug.lua
+++ b/lua/tardis/libraries/libraries/sh_debug.lua
@@ -223,6 +223,52 @@ concommand.Add("tardis2_debug_ply_pos", function(ply,cmd,args)
     print(tostring(int:WorldToLocal(ply:GetPos())))
 end)
 
+concommand.Add("tardis2_debug_minmax", function(ply,cmd,args)
+    local int = ply:GetTardisData("interior")
+    if not IsValid(int) or not ply:IsAdmin() then return end
+
+    int.ExitBox = {
+        Min = Vector(-16384, -16384, -16384),
+        Max = Vector(16384, 16384, 16384),
+    }
+    ply:ChatPrint("ExitDistance/Box disabled")
+
+    local function create_pointer(pos)
+        local p = ents.Create("gmod_tardis_debug_pointer")
+        p:SetCreator(ply)
+        p:SetPos(int:LocalToWorld(pos))
+        int:DeleteOnRemove(p)
+        return p
+    end
+
+    local min, max
+    if args[1] == "exit" and int.metadata.Interior.ExitBox.Min and int.metadata.Interior.ExitBox.Max then
+        min = int.metadata.Interior.ExitBox.Min
+        max = int.metadata.Interior.ExitBox.Max
+        ply:ChatPrint("Created pointers for T.Interior.ExitBox")
+    elseif (args[1] == "size" or not args[1]) and int.metadata.Interior.Size.Min and int.metadata.Interior.Size.Max then
+        min = int.metadata.Interior.Size.Min
+        max = int.metadata.Interior.Size.Max
+        ply:ChatPrint("Created pointers for T.Interior.Size")
+    else
+        ply:ChatPrint("Min/Max not found, creating two default pointers")
+        local hitPos = ply:GetEyeTraceNoCursor().HitPos
+        min = int:WorldToLocal(hitPos)
+        max = int:WorldToLocal(hitPos + Vector(0,0,100))
+    end
+
+    local min_pointer = create_pointer(min)
+    local max_pointer = create_pointer(max)
+    
+    min_pointer:SetOther(max_pointer)
+    min_pointer:SetDrawAABox(true)
+    min_pointer:Spawn()
+    min_pointer:Activate()
+    
+    max_pointer:Spawn()
+    max_pointer:Activate()
+end)
+
 if SERVER then
     util.AddNetworkString("TARDIS-Debug")
 end

--- a/lua/tardis/sh_metadata.lua
+++ b/lua/tardis/sh_metadata.lua
@@ -84,10 +84,68 @@ function TARDIS:ClearMetadata(id)
     end
 end
 
+function TARDIS:ValidateMetadata(t)
+    if t.Interior then
+        if t.Interior.Size and (t.Interior.Size.Min or t.Interior.Size.Max) then
+            if not t.Interior.Size.Min then
+                return "Interior.Size.Min not set"
+            end
+
+            if not t.Interior.Size.Max then
+                return "Interior.Size.Max not set"
+            end
+
+            if t.Interior.Size.Min.x >= t.Interior.Size.Max.x then
+                return "Interior.Size.Min.x >= Maxs.x"
+            end
+
+            if t.Interior.Size.Min.y >= t.Interior.Size.Max.y then
+                return "Interior.Size.Min.y >= Maxs.y"
+            end
+
+            if t.Interior.Size.Min.z >= t.Interior.Size.Max.z then
+                return "Interior.Size.Min.z >= Maxs.z"
+            end
+        end
+
+        if t.Interior.ExitBox and (t.Interior.ExitBox.Min or t.Interior.ExitBox.Max) then
+            if not t.Interior.ExitBox.Min then
+                return "Interior.ExitBox.Min not set"
+            end
+
+            if not t.Interior.ExitBox.Max then
+                return "Interior.ExitBox.Max not set"
+            end
+
+            if t.Interior.ExitDistance then
+                return "Interior.ExitDistance cannot be used with Interior.ExitBox"
+            end
+
+            if t.Interior.ExitBox.Min.x >= t.Interior.ExitBox.Max.x then
+                return "Interior.ExitBox.Min.x >= Maxs.x"
+            end
+
+            if t.Interior.ExitBox.Min.y >= t.Interior.ExitBox.Max.y then
+                return "Interior.ExitBox.Min.y >= Maxs.y"
+            end
+
+            if t.Interior.ExitBox.Min.z >= t.Interior.ExitBox.Max.z then
+                return "Interior.ExitBox.Min.z >= Maxs.z"
+            end
+        end
+    end
+end
+
 function TARDIS:AddInterior(t)
     local id = t.ID
 
     self.MetadataRaw[id] = t
+
+    local error = self:ValidateMetadata(t)
+    if error then
+        ErrorNoHalt("TARDIS: Error in interior '"..id.."' metadata: "..error.."\n")
+        return
+    end
 
     self:ClearMetadata(id)
 


### PR DESCRIPTION
These changes allow an extension developer to manually specify two new aspects of their interior to give finer control:

`T.Interior.Size`: Previously calculated from the primary interior entities bounding box, this can now be manually specified for greater control, which is most useful when the main model is only part of the interior for complex / large interiors. If unset, this will default to the previous behaviour.

`T.Interior.ExitBox`: This is a recommended alternative to `T.Interior.ExitDistance`. Similarly to `T.Interior.Size`, this allows you to manually set a bounding box for when the player will be ejected from the interior for going outside of.

The difference between the two is that `Size` is only used to calculate positioning and space when spawning the interior in the skybox, while `ExitDistance`/ `ExitBox` is used for player interactions and visibility.

Note that some features still require a sphere/radius so when `ExitBox` is set, a sphere radius and center is automatically calculated from the box, such as the spacebuild environment sphere.

Also note that the `ExitBox` is already a built in feature in the Doors addon which is why we are not doing any special handling there.

There is also a new debug tool to help set up these min/max boxes: `tardis2_debug_minmax` which takes an optional parameter of either `size` or `exit` which tells the pointers where to spawn initially, using the existing `T.Interior.Size` or `T.Interior.ExitBox` vectors, if available. If unspecified it will default to `size` and if they don't exist or you specify any other argument it will create two pointers in front of you instead.

These two arrows will draw a wireframe box between them which you can use to find the correct min/max values in a visual way.

I have set up both the `Size` and `ExitBox` for the default interior.

Fixes #555 
Fixes #967