### PR TITLE
Feed activator entity into the CanPlayerEnterDoor hook

### DIFF
--- a/lua/entities/gmod_tardis/modules/sv_interior.lua
+++ b/lua/entities/gmod_tardis/modules/sv_interior.lua
@@ -2,7 +2,7 @@
 
 ENT:AddHook("Use", "interior", function(self,a,c)
     if a:KeyDown(IN_WALK) or not IsValid(self.interior) or self:GetData("legacy_door_type") then
-        if self:CallHook("CanPlayerEnterDoor")~=false then
+        if self:CallHook("CanPlayerEnterDoor", a)~=false then
             self:PlayerEnter(a)
         end
     else


### PR DESCRIPTION
Useful if developers would like to do checks on the player before allowing them access to the TARDIS. For example in an RP scenario, if they are the right role.