### PR TITLE
Added some useful common material proxies that i think would really help

### DIFF
--- a/lua/matproxy/matproxy_tardis.lua
+++ b/lua/matproxy/matproxy_tardis.lua
@@ -137,3 +137,126 @@ matproxy.Add({
         mat:SetVector(self.ResultTo, col)
     end
 })
+
+matproxy.Add({
+    name = "TARDIS_Interior_Color1",
+
+    init = function(self, mat, values)
+        self.ResultTo = values.resultvar
+    end,
+
+    bind = function(self, mat, ent)
+        if not IsValid(ent) or not ent.TardisPart then return end
+        if not ent.interior then return end
+
+        local col = ent.interior.metadata.Interior.MatProxy.Color1
+
+
+        col = Color(col.r, col.g, col.b):ToVector()
+
+
+
+        mat:SetVector( self.ResultTo, col);
+    end
+})
+
+matproxy.Add({
+    name = "TARDIS_Interior_Color2",
+
+    init = function(self, mat, values)
+        self.ResultTo = values.resultvar
+    end,
+
+    bind = function(self, mat, ent)
+        if not IsValid(ent) or not ent.TardisPart then return end
+        if not ent.interior then return end
+
+        local col = ent.interior.metadata.Interior.MatProxy.Color2
+
+
+        col = Color(col.r, col.g, col.b):ToVector()
+
+
+
+        mat:SetVector( self.ResultTo, col);
+    end
+})
+
+matproxy.Add({
+    name = "TARDIS_Interior_Color3",
+
+    init = function(self, mat, values)
+        self.ResultTo = values.resultvar
+    end,
+
+    bind = function(self, mat, ent)
+        if not IsValid(ent) or not ent.TardisPart then return end
+        if not ent.interior then return end
+
+        local col = ent.interior.metadata.Interior.MatProxy.Color3
+
+
+        col = Color(col.r, col.g, col.b):ToVector()
+
+
+
+        mat:SetVector( self.ResultTo, col);
+    end
+})
+
+local function matproxy_tardis_warning_init(self, mat, values)
+    self.ResultTo = values.resultvar
+    self.on_var = values.onvar
+    self.off_var = values.offvar
+end
+
+local function matproxy_tardis_warning_bind(self, mat, ent)
+    if not IsValid(ent) or not IsValid(ent.exterior) or not ent.TardisPart then return end
+
+    local var = ent.exterior:GetWarning() and self.on_var or self.off_var
+    if not var then return end
+
+    local value = mat:GetVector(var)
+
+    if var ~= self.last_var or value ~= self.last_value then
+        self.last_var = var
+        self.last_value = value
+        mat:SetVector(self.ResultTo, value)
+    end
+
+end
+
+matproxy.Add({
+    name = "TARDIS_Warning",
+    init = matproxy_tardis_warning_init,
+    bind = matproxy_tardis_warning_bind,
+})
+
+
+local function matproxy_tardis_HDR_init(self, mat, values)
+    self.ResultTo = values.resultvar
+    self.on_var = values.onvar
+    self.off_var = values.offvar
+end
+
+local function matproxy_tardis_HDR_bind(self, mat, ent)
+    if not IsValid(ent) or not IsValid(ent.exterior) or not ent.TardisPart then return end
+
+    local var = render.GetHDREnabled() and self.on_var or self.off_var
+    if not var then return end
+
+    local value = mat:GetVector(var)
+
+    if var ~= self.last_var or value ~= self.last_value then
+        self.last_var = var
+        self.last_value = value
+        mat:SetVector(self.ResultTo, value)
+    end
+
+end
+
+matproxy.Add({
+    name = "TARDIS_HDR_State",
+    init = matproxy_tardis_HDR_init,
+    bind = matproxy_tardis_HDR_bind,
+})


### PR DESCRIPTION
i find myself using these material proxies a lot in my extensions, and to avoid having them be dependent on each other i have to copy them between them a lot, so i thought that it would be better to get them implemented into the base addon as not only would that make it a little easier for me, but it would allow everyone else to use them too

the included material proxies are:

3 colour ones that allow you to define colours in the interior file, extremely useful for when you want different settings for colours without having to worry about changing any materials, i basically always use these for my colour options as they're the most efficient way so i think they would fit perfectly in the base addon

a warning one that functions the same as the power one, just detecting the warning state, allows you to do some basic tinting of some lights instead of again having a whole other material with texturesets, can simplify things a lot

and a HDR detecting one, allowing you to slightly tweak parameters of a material whether or not the player has HDR enabled or not, i use this to fix the skybox issue in my addons but it can be used for smaller details like simple envmaps

overall i think these would really help on the dev side of things, because not only is it a little tedious to copy these between addons when i have to use them in other places, but i don't want to gatekeep these things i've thrown together, i want others to use them too as it can make things so much easier