### PR TITLE
Overhauled material proxies to fix some issues

### DIFF
--- a/lua/matproxy/matproxy_tardis.lua
+++ b/lua/matproxy/matproxy_tardis.lua
@@ -147,7 +147,16 @@ matproxy.Add({
 
     bind = function(self, mat, ent)
         if not IsValid(ent) or not ent.TardisPart then return end
-        if not ent.interior then return end
+        if not ent.interior.metadata.Interior.MatProxy then
+            local col = Color(255, 255, 255)
+
+
+            col = Color(col.r, col.g, col.b):ToVector()
+
+
+
+            mat:SetVector( self.ResultTo, col);
+        return end
 
         local col = ent.interior.metadata.Interior.MatProxy.Color1
 
@@ -169,10 +178,18 @@ matproxy.Add({
 
     bind = function(self, mat, ent)
         if not IsValid(ent) or not ent.TardisPart then return end
-        if not ent.interior then return end
+        if not ent.interior.metadata.Interior.MatProxy then
+            local col = Color(255, 255, 255)
+
+
+            col = Color(col.r, col.g, col.b):ToVector()
+
+
+
+            mat:SetVector( self.ResultTo, col);
+        return end
 
         local col = ent.interior.metadata.Interior.MatProxy.Color2
-
 
         col = Color(col.r, col.g, col.b):ToVector()
 
@@ -191,7 +208,16 @@ matproxy.Add({
 
     bind = function(self, mat, ent)
         if not IsValid(ent) or not ent.TardisPart then return end
-        if not ent.interior then return end
+        if not ent.interior.metadata.Interior.MatProxy then
+            local col = Color(255, 255, 255)
+
+
+            col = Color(col.r, col.g, col.b):ToVector()
+
+
+
+            mat:SetVector( self.ResultTo, col);
+        return end
 
         local col = ent.interior.metadata.Interior.MatProxy.Color3
 

--- a/lua/matproxy/matproxy_tardis.lua
+++ b/lua/matproxy/matproxy_tardis.lua
@@ -90,19 +90,27 @@ local function matproxy_tardis_power_init(self, mat, values)
 end
 
 local function matproxy_tardis_power_bind(self, mat, ent)
-    if not IsValid(ent) or not IsValid(ent.exterior) or not ent.TardisPart then return end
+    if not IsValid(ent) then return end
 
-    local var = ent.exterior:GetPower() and self.on_var or self.off_var
-    if not var then return end
-
-    local value = mat:GetVector(var)
-
-    if var ~= self.last_var or value ~= self.last_value then
-        self.last_var = var
-        self.last_value = value
-        mat:SetVector(self.ResultTo, value)
+    if ent.interior then
+        ent = ent.interior
     end
 
+    if ent.exterior then
+        local var = ent.exterior:GetPower() and self.on_var or self.off_var
+        if not var then return end
+
+        local value = mat:GetVector(var)
+
+        if var ~= self.last_var or value ~= self.last_value then
+            self.last_var = var
+            self.last_value = value
+            mat:SetVector(self.ResultTo, value)
+        end
+    else
+        local value = Vector(1, 1, 1)
+        mat:SetVector(self.ResultTo, value)
+    end
 end
 
 matproxy.Add({
@@ -220,16 +228,25 @@ local function matproxy_tardis_warning_init(self, mat, values)
 end
 
 local function matproxy_tardis_warning_bind(self, mat, ent)
-    if not IsValid(ent) or not IsValid(ent.exterior) or not ent.TardisPart then return end
+    if not IsValid(ent) then return end
 
-    local var = ent.exterior:GetWarning() and self.on_var or self.off_var
-    if not var then return end
+    if ent.interior then
+        ent = ent.interior
+    end
 
-    local value = mat:GetVector(var)
+    if ent.exterior then
+        local var = ent.exterior:GetWarning() and self.on_var or self.off_var
+        if not var then return end
 
-    if var ~= self.last_var or value ~= self.last_value then
-        self.last_var = var
-        self.last_value = value
+        local value = mat:GetVector(var)
+
+        if var ~= self.last_var or value ~= self.last_value then
+            self.last_var = var
+            self.last_value = value
+            mat:SetVector(self.ResultTo, value)
+        end
+    else
+        local value = Vector(1, 1, 1)
         mat:SetVector(self.ResultTo, value)
     end
 

--- a/lua/matproxy/matproxy_tardis.lua
+++ b/lua/matproxy/matproxy_tardis.lua
@@ -1,3 +1,6 @@
+local fallbackcol = Color(255, 255, 255)
+fallbackcol = Color(fallbackcol.r, fallbackcol.g, fallbackcol.b):ToVector()
+
 matproxy.Add({
     name = "TARDIS_State_Texture",
 
@@ -108,8 +111,7 @@ local function matproxy_tardis_power_bind(self, mat, ent)
             mat:SetVector(self.ResultTo, value)
         end
     else
-        local value = Vector(1, 1, 1)
-        mat:SetVector(self.ResultTo, value)
+        mat:SetVector(self.ResultTo, fallbackcol)
     end
 end
 
@@ -146,9 +148,6 @@ matproxy.Add({
     end
 })
 
-local fallbackcol = Color(255, 255, 255)
-fallbackcol = Color(fallbackcol.r, fallbackcol.g, fallbackcol.b):ToVector()
-
 matproxy.Add({
     name = "TARDIS_Interior_Color1",
 
@@ -165,10 +164,10 @@ matproxy.Add({
             if ent.metadata.Interior.MatProxy then
                 local col = ent.metadata.Interior.MatProxy.Color1
                 col = Color(col.r, col.g, col.b):ToVector()
-                mat:SetVector( self.ResultTo, col)
+                mat:SetVector(self.ResultTo, col)
             end
         else
-            mat:SetVector( self.ResultTo, fallbackcol);
+            mat:SetVector(self.ResultTo, fallbackcol);
         end
     end
 })
@@ -189,10 +188,10 @@ matproxy.Add({
             if ent.metadata.Interior.MatProxy then
                 local col = ent.metadata.Interior.MatProxy.Color2
                 col = Color(col.r, col.g, col.b):ToVector()
-                mat:SetVector( self.ResultTo, col)
+                mat:SetVector(self.ResultTo, col)
             end
         else
-            mat:SetVector( self.ResultTo, fallbackcol);
+            mat:SetVector(self.ResultTo, fallbackcol);
         end
     end
 })
@@ -213,10 +212,10 @@ matproxy.Add({
             if ent.metadata.Interior.MatProxy then
                 local col = ent.metadata.Interior.MatProxy.Color3
                 col = Color(col.r, col.g, col.b):ToVector()
-                mat:SetVector( self.ResultTo, col)
+                mat:SetVector(self.ResultTo, col)
             end
         else
-            mat:SetVector( self.ResultTo, fallbackcol);
+            mat:SetVector(self.ResultTo, fallbackcol);
         end
     end
 })
@@ -246,8 +245,7 @@ local function matproxy_tardis_warning_bind(self, mat, ent)
             mat:SetVector(self.ResultTo, value)
         end
     else
-        local value = Vector(1, 1, 1)
-        mat:SetVector(self.ResultTo, value)
+        mat:SetVector(self.ResultTo, fallbackcol)
     end
 
 end

--- a/lua/matproxy/matproxy_tardis.lua
+++ b/lua/matproxy/matproxy_tardis.lua
@@ -138,6 +138,9 @@ matproxy.Add({
     end
 })
 
+local fallbackcol = Color(255, 255, 255)
+fallbackcol = Color(fallbackcol.r, fallbackcol.g, fallbackcol.b):ToVector()
+
 matproxy.Add({
     name = "TARDIS_Interior_Color1",
 
@@ -149,14 +152,7 @@ matproxy.Add({
         if not IsValid(ent) or not ent.TardisPart then return end
         if not ent.interior then return end
         if not ent.interior.metadata.Interior.MatProxy then
-            local col = Color(255, 255, 255)
-
-
-            col = Color(col.r, col.g, col.b):ToVector()
-
-
-
-            mat:SetVector( self.ResultTo, col);
+            mat:SetVector( self.ResultTo, fallbackcol);
         return end
 
         local col = ent.interior.metadata.Interior.MatProxy.Color1
@@ -181,14 +177,7 @@ matproxy.Add({
         if not IsValid(ent) or not ent.TardisPart then return end
         if not ent.interior then return end
         if not ent.interior.metadata.Interior.MatProxy then
-            local col = Color(255, 255, 255)
-
-
-            col = Color(col.r, col.g, col.b):ToVector()
-
-
-
-            mat:SetVector( self.ResultTo, col);
+            mat:SetVector( self.ResultTo, fallbackcol);
         return end
 
         local col = ent.interior.metadata.Interior.MatProxy.Color2
@@ -212,14 +201,7 @@ matproxy.Add({
         if not IsValid(ent) or not ent.TardisPart then return end
         if not ent.interior then return end
         if not ent.interior.metadata.Interior.MatProxy then
-            local col = Color(255, 255, 255)
-
-
-            col = Color(col.r, col.g, col.b):ToVector()
-
-
-
-            mat:SetVector( self.ResultTo, col);
+            mat:SetVector( self.ResultTo, fallbackcol);
         return end
 
 

--- a/lua/matproxy/matproxy_tardis.lua
+++ b/lua/matproxy/matproxy_tardis.lua
@@ -149,20 +149,19 @@ matproxy.Add({
     end,
 
     bind = function(self, mat, ent)
-        if not IsValid(ent) or not ent.TardisPart then return end
-        if not ent.interior then return end
-        if not ent.interior.metadata.Interior.MatProxy then
+        if not IsValid(ent) then return end
+        if ent.interior then
+            ent = ent.interior
+        end
+        if ent.exterior then
+            if ent.metadata.Interior.MatProxy then
+                local col = ent.metadata.Interior.MatProxy.Color2
+                col = Color(col.r, col.g, col.b):ToVector()
+                mat:SetVector( self.ResultTo, col)
+            end
+        else
             mat:SetVector( self.ResultTo, fallbackcol);
-        return end
-
-        local col = ent.interior.metadata.Interior.MatProxy.Color1
-
-
-        col = Color(col.r, col.g, col.b):ToVector()
-
-
-
-        mat:SetVector( self.ResultTo, col);
+        end
     end
 })
 
@@ -174,19 +173,19 @@ matproxy.Add({
     end,
 
     bind = function(self, mat, ent)
-        if not IsValid(ent) or not ent.TardisPart then return end
-        if not ent.interior then return end
-        if not ent.interior.metadata.Interior.MatProxy then
+        if not IsValid(ent) then return end
+        if ent.interior then
+            ent = ent.interior
+        end
+        if ent.exterior then
+            if ent.metadata.Interior.MatProxy then
+                local col = ent.metadata.Interior.MatProxy.Color2
+                col = Color(col.r, col.g, col.b):ToVector()
+                mat:SetVector( self.ResultTo, col)
+            end
+        else
             mat:SetVector( self.ResultTo, fallbackcol);
-        return end
-
-        local col = ent.interior.metadata.Interior.MatProxy.Color2
-
-        col = Color(col.r, col.g, col.b):ToVector()
-
-
-
-        mat:SetVector( self.ResultTo, col);
+        end
     end
 })
 
@@ -198,21 +197,19 @@ matproxy.Add({
     end,
 
     bind = function(self, mat, ent)
-        if not IsValid(ent) or not ent.TardisPart then return end
-        if not ent.interior then return end
-        if not ent.interior.metadata.Interior.MatProxy then
+        if not IsValid(ent) then return end
+        if ent.interior then
+            ent = ent.interior
+        end
+        if ent.exterior then
+            if ent.metadata.Interior.MatProxy then
+                local col = ent.metadata.Interior.MatProxy.Color3
+                col = Color(col.r, col.g, col.b):ToVector()
+                mat:SetVector( self.ResultTo, col)
+            end
+        else
             mat:SetVector( self.ResultTo, fallbackcol);
-        return end
-
-
-        local col = ent.interior.metadata.Interior.MatProxy.Color3
-
-
-        col = Color(col.r, col.g, col.b):ToVector()
-
-
-
-        mat:SetVector( self.ResultTo, col);
+        end
     end
 })
 

--- a/lua/matproxy/matproxy_tardis.lua
+++ b/lua/matproxy/matproxy_tardis.lua
@@ -163,7 +163,7 @@ matproxy.Add({
         end
         if ent.exterior then
             if ent.metadata.Interior.MatProxy then
-                local col = ent.metadata.Interior.MatProxy.Color2
+                local col = ent.metadata.Interior.MatProxy.Color1
                 col = Color(col.r, col.g, col.b):ToVector()
                 mat:SetVector( self.ResultTo, col)
             end

--- a/lua/matproxy/matproxy_tardis.lua
+++ b/lua/matproxy/matproxy_tardis.lua
@@ -147,6 +147,7 @@ matproxy.Add({
 
     bind = function(self, mat, ent)
         if not IsValid(ent) or not ent.TardisPart then return end
+        if not ent.interior then return end
         if not ent.interior.metadata.Interior.MatProxy then
             local col = Color(255, 255, 255)
 
@@ -178,6 +179,7 @@ matproxy.Add({
 
     bind = function(self, mat, ent)
         if not IsValid(ent) or not ent.TardisPart then return end
+        if not ent.interior then return end
         if not ent.interior.metadata.Interior.MatProxy then
             local col = Color(255, 255, 255)
 
@@ -208,6 +210,7 @@ matproxy.Add({
 
     bind = function(self, mat, ent)
         if not IsValid(ent) or not ent.TardisPart then return end
+        if not ent.interior then return end
         if not ent.interior.metadata.Interior.MatProxy then
             local col = Color(255, 255, 255)
 
@@ -218,6 +221,7 @@ matproxy.Add({
 
             mat:SetVector( self.ResultTo, col);
         return end
+
 
         local col = ent.interior.metadata.Interior.MatProxy.Color3
 


### PR DESCRIPTION
theres been a few bugs with material proxies when it comes to them functioning on the main entities for the interior and exterior, i've gone in an overhauled both my own and the original power one to allow those to function on the main entities, as a side thing i also made it so if its used on a tardis or a prop that does not feature the material proxy functionality, it will default to white, this both removes some errors being thrown and also allows people to spawn in the props without the colours being weird