### PR TITLE
Material proxy that returns the light level of the exterior

### DIFF
--- a/lua/matproxy/matproxy_tardis.lua
+++ b/lua/matproxy/matproxy_tardis.lua
@@ -284,3 +284,25 @@ matproxy.Add({
     init = matproxy_tardis_HDR_init,
     bind = matproxy_tardis_HDR_bind,
 })
+
+matproxy.Add({
+    name = "TARDIS_ExteriorBaseLight",
+
+    init = function(self, mat, values)
+        self.ResultTo = values.resultvar
+    end,
+
+    bind = function(self, mat, ent)
+        if not IsValid(ent) then return end
+        if ent.interior then
+            ent = ent.interior
+        end
+        if ent.exterior then
+            ent = ent.exterior
+            local col = render.ComputeLighting((ent:GetPos()+Vector(0, 0, 1)),Vector(0, 0, 1) ) -- Gets the position just above the tardis origin just in case it spawns slightly in the ground
+            mat:SetVector(self.ResultTo, col)
+        else
+            mat:SetVector(self.ResultTo, fallbackcol);
+        end
+    end
+})

--- a/lua/matproxy/matproxy_tardis.lua
+++ b/lua/matproxy/matproxy_tardis.lua
@@ -302,7 +302,7 @@ matproxy.Add({
             end
             vortexcol = Color(vortexcol.r, vortexcol.g, vortexcol.b):ToVector()
             ent = ent.exterior
-            local col = render.ComputeLighting((ent:GetPos()+Vector(0, 0, 80)),ent:GetForward()) -- Gets the position just above the tardis origin just in case it spawns slightly in the ground
+            local col = render.ComputeLighting((ent:GetPos()+Vector(0, 0, 80)),ent:GetForward()) -- Gets the lighting from the perspective of the doors
             if ent:GetData("teleport") or ent:GetData("vortex") then
                 local ExteriorAlpha = (ent:GetData("alpha",255)/255)
                 local ExteriorAlphaInvert = ((ExteriorAlpha - 1)*-1)

--- a/lua/matproxy/matproxy_tardis.lua
+++ b/lua/matproxy/matproxy_tardis.lua
@@ -110,8 +110,6 @@ local function matproxy_tardis_power_bind(self, mat, ent)
             self.last_value = value
             mat:SetVector(self.ResultTo, value)
         end
-    else
-        mat:SetVector(self.ResultTo, fallbackcol)
     end
 end
 
@@ -244,8 +242,6 @@ local function matproxy_tardis_warning_bind(self, mat, ent)
             self.last_value = value
             mat:SetVector(self.ResultTo, value)
         end
-    else
-        mat:SetVector(self.ResultTo, fallbackcol)
     end
 
 end

--- a/lua/matproxy/matproxy_tardis.lua
+++ b/lua/matproxy/matproxy_tardis.lua
@@ -298,8 +298,18 @@ matproxy.Add({
             ent = ent.interior
         end
         if ent.exterior then
+            local vortexcol = Color(0, 0, 0) -- Uses black if no custom colour is set since that can fit for any tardis
+            if ent.metadata.Interior.MatProxy then
+                if ent.metadata.Interior.MatProxy.VortexColor then -- Making sure a vortex colour is set in the first place since people tend to re-use door on multiple tardises
+                    vortexcol = ent.metadata.Interior.MatProxy.VortexColor
+                end
+            end
+            vortexcol = Color(vortexcol.r, vortexcol.g, vortexcol.b):ToVector()
             ent = ent.exterior
             local col = render.ComputeLighting((ent:GetPos()+Vector(0, 0, 1)),Vector(0, 0, 1) ) -- Gets the position just above the tardis origin just in case it spawns slightly in the ground
+            local ExteriorAlpha = (ent:GetData("alpha",255)/255)
+            local ExteriorAlphaInvert = ((ExteriorAlpha - 1)*-1)
+            col = ((col*ExteriorAlpha) + (vortexcol*ExteriorAlphaInvert)) -- Essentially calculates how dematerialised it is and fades the colour accordingly
             mat:SetVector(self.ResultTo, col)
         else
             mat:SetVector(self.ResultTo, fallbackcol);

--- a/lua/matproxy/matproxy_tardis.lua
+++ b/lua/matproxy/matproxy_tardis.lua
@@ -306,7 +306,7 @@ matproxy.Add({
             end
             vortexcol = Color(vortexcol.r, vortexcol.g, vortexcol.b):ToVector()
             ent = ent.exterior
-            local col = render.ComputeLighting((ent:GetPos()+Vector(0, 0, 1)),Vector(0, 0, 1) ) -- Gets the position just above the tardis origin just in case it spawns slightly in the ground
+            local col = render.ComputeLighting((ent:GetPos()+Vector(0, 0, 80)),ent:GetForward()) -- Gets the position just above the tardis origin just in case it spawns slightly in the ground
             local ExteriorAlpha = (ent:GetData("alpha",255)/255)
             local ExteriorAlphaInvert = ((ExteriorAlpha - 1)*-1)
             col = ((col*ExteriorAlpha) + (vortexcol*ExteriorAlphaInvert)) -- Essentially calculates how dematerialised it is and fades the colour accordingly

--- a/lua/matproxy/matproxy_tardis.lua
+++ b/lua/matproxy/matproxy_tardis.lua
@@ -300,7 +300,7 @@ matproxy.Add({
                     vortexcol = ent.metadata.Interior.MatProxy.VortexColor
                 end
             end
-            vortexcol = Color(vortexcol.r, vortexcol.g, vortexcol.b):ToVector()
+            vortexcol = (Color(vortexcol.r, vortexcol.g, vortexcol.b):ToVector()*2.5)
             ent = ent.exterior
             local col = render.ComputeLighting((ent:GetPos()+Vector(0, 0, 80)),ent:GetForward()) -- Gets the lighting from the perspective of the doors
             if ent:GetData("teleport") or ent:GetData("vortex") then

--- a/lua/matproxy/matproxy_tardis.lua
+++ b/lua/matproxy/matproxy_tardis.lua
@@ -303,9 +303,11 @@ matproxy.Add({
             vortexcol = Color(vortexcol.r, vortexcol.g, vortexcol.b):ToVector()
             ent = ent.exterior
             local col = render.ComputeLighting((ent:GetPos()+Vector(0, 0, 80)),ent:GetForward()) -- Gets the position just above the tardis origin just in case it spawns slightly in the ground
-            local ExteriorAlpha = (ent:GetData("alpha",255)/255)
-            local ExteriorAlphaInvert = ((ExteriorAlpha - 1)*-1)
-            col = ((col*ExteriorAlpha) + (vortexcol*ExteriorAlphaInvert)) -- Essentially calculates how dematerialised it is and fades the colour accordingly
+            if ent:GetData("teleport") or ent:GetData("vortex") then
+                local ExteriorAlpha = (ent:GetData("alpha",255)/255)
+                local ExteriorAlphaInvert = ((ExteriorAlpha - 1)*-1)
+                col = ((col*ExteriorAlpha) + (vortexcol*ExteriorAlphaInvert)) -- Essentially calculates how dematerialised it is and fades the colour accordingly
+            end
             mat:SetVector(self.ResultTo, col)
         else
             mat:SetVector(self.ResultTo, fallbackcol);

--- a/lua/matproxy/matproxy_tardis.lua
+++ b/lua/matproxy/matproxy_tardis.lua
@@ -304,9 +304,9 @@ matproxy.Add({
             ent = ent.exterior
             local col = render.ComputeLighting((ent:GetPos()+Vector(0, 0, 80)),ent:GetForward()) -- Gets the lighting from the perspective of the doors
             if ent:GetData("teleport") or ent:GetData("vortex") then
-                local ExteriorAlpha = (ent:GetData("alpha",255)/255)
-                local ExteriorAlphaInvert = ((ExteriorAlpha - 1)*-1)
-                col = ((col*ExteriorAlpha) + (vortexcol*ExteriorAlphaInvert)) -- Essentially calculates how dematerialised it is and fades the colour accordingly
+                local exterioralpha = (ent:GetData("alpha",255)/255)
+                local exterioralphainvert = ((exterioralpha - 1)*-1)
+                col = ((col*exterioralpha) + (vortexcol*exterioralphainvert)) -- Essentially calculates how dematerialised it is and fades the colour accordingly
             end
             mat:SetVector(self.ResultTo, col)
         else


### PR DESCRIPTION
essentially this would be used for things like tinting the light of interior windows, its able to read from map lighting and player placed lights, unfortunately i couldn't figure out how to make it react to lamps too.

i also made it so it fades to the vortex colour on demat, if a vortex colour isn't set it'll just fade to black to match the appreance in the husbands of river song since that can apply to any tardis

this could also be used for other things, for example tinting an exterior envmap to match the world lighting, and thats just what i can think of off the top of my head, people don't have to use it but it has a lot of potential i think so it would be nice if this was part of the base addon for everyone

also, credit to DoctorHugoSource for the overall idea of the implementation (the code itself is my own)

<img width="700" height="861" alt="image" src="https://github.com/user-attachments/assets/4096d398-fa92-4543-b98e-7ad399c279a0" />
<img width="612" height="852" alt="image" src="https://github.com/user-attachments/assets/77c2a877-3390-4ef1-ba5d-1377e931be26" />
<img width="655" height="788" alt="image" src="https://github.com/user-attachments/assets/7f1c01d1-9dfc-4347-b933-00e9e41960d8" />
<img width="814" height="1009" alt="image" src="https://github.com/user-attachments/assets/08847450-267f-4b07-9350-9c7fdcfa03d8" />
<img width="714" height="1004" alt="image" src="https://github.com/user-attachments/assets/ad090224-d845-493f-9cb9-be917516a6bd" />
