### PR TITLE
Enable assign-type-mismatch diagnostic; triage the rest

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -7,8 +7,7 @@
             "need-check-nil",
             "unchecked-nil-access",
             "undefined-field",
-            "param-type-mismatch",
-            "assign-type-mismatch"
+            "param-type-mismatch"
         ]
     },
     "workspace": {

--- a/.luatypes/glua_overrides.lua
+++ b/.luatypes/glua_overrides.lua
@@ -1,19 +1,10 @@
 ---@meta
 
--- glua-api-snippets declares enum aliases (MASK, COLLISION_GROUP, _USE, etc.) as
--- string-literal unions for autocomplete, but the corresponding MASK_*, COLLISION_GROUP_*,
--- *_USE constants are plain integers at runtime. Re-declare the aliases as `integer` so
--- assignments like `Trace.mask = MASK_NPCWORLDSTATIC` type-check.
-
----@alias MASK integer
----@alias COLLISION_GROUP integer
----@alias _USE integer
----@alias DMG integer
----@alias RT_SIZE integer
----@alias MATERIAL_RT_DEPTH integer
----@alias CREATERENDERTARGETFLAGS integer
----@alias BOX integer
----@alias DOCK integer
+-- glua-api-snippets types Trace.mask as the MASK enum union, but the MASK_*
+-- constants are plain integers at runtime, so `Trace.mask = MASK_NPCWORLDSTATIC`
+-- warns as assign-type-mismatch. Widening the field to integer clears it.
+---@class Trace
+---@field mask integer
 
 -- glua-api-snippets types debug.getinfo's first param as `function`, but the
 -- runtime accepts a stack-level number too (and that's how TARDIS uses it).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,14 @@ Useful when a fix has rippled across the codebase or when picking up the project
 
 #### Removing `---@diagnostic disable` rules from `.luarc.json`
 
-The current block — `need-check-nil`, `unchecked-nil-access`, `undefined-field`, `param-type-mismatch`, `assign-type-mismatch` — was re-added wholesale on the glua_ls 1.0.15 → 1.0.27 bump: 1.0.20+'s flow-based nil analysis and stricter inference flood ~400 false positives on TARDIS's dynamic `self` dispatch, runtime-set entity fields, and integer-enum usage (zero real bugs). Whittle it back down per the guidance below as `Pollux12/gmod-glua-ls` fixes the false positives.
+The block was re-added wholesale on the glua_ls 1.0.15 → 1.0.27 bump: 1.0.20+'s flow-based nil analysis and stricter inference flood ~400 false positives on TARDIS's dynamic `self` dispatch, runtime-set entity fields, and integer-enum usage (zero real bugs). Whittle it back down per the guidance below as `Pollux12/gmod-glua-ls` fixes the false positives.
+
+Per-rule status after a full triage of every diagnostic:
+
+- `assign-type-mismatch` — **enabled.** 5 false positives, all fixed: 4 `Trace.mask = MASK_*` cleared by widening the field in `.luatypes/glua_overrides.lua` (the older `---@alias MASK integer` no longer overrides the stub's union on 1.0.27), 1 `screen.id` marker via a one-line `disable-next-line`.
+- `param-type-mismatch` — **disabled.** 42 warnings, all false positives, zero real bugs: 38 integer-enum (`DOCK`/`MASK`/`COLLISION_GROUP`/`DMG`/render-target enums) where both central fixes are dead on 1.0.27 (alias re-declaration AND `@overload` widening), plus 4 inference quirks (`parseTriple` data-or-error returns, a `pairs()` key). Re-enable only once upstream restores enum-alias overriding.
+- `undefined-field` — **disabled.** 84 false positives: metatable-OOP `self` dispatch (`cl_hexagonal_layout`), runtime-set entity fields, custom panel fields, real GMod methods on under-typed vars, dynamic-key tables. A repo-wide bug-hunt for never-assigned/non-method fields found no real typos. Clearing it needs the speculative class annotations warned against below.
+- `unchecked-nil-access` (133) / `need-check-nil` (188 hints) — **disabled.** The bulk of the flood: locals from the nullable entity-lookup helpers used in validity-guaranteed contexts, and field accesses the analyzer won't narrow. Making the helpers non-nullable would be wrong (they genuinely return nil). No clean source-side fix without pervasive local-extraction refactors.
 
 When enabling a previously-disabled rule, prefer source-side type annotations over per-callsite asserts or `---@cast` directives — annotations propagate automatically; callsite workarounds need to be repeated everywhere.
 

--- a/lua/tardis/sh_screen_ui.lua
+++ b/lua/tardis/sh_screen_ui.lua
@@ -255,6 +255,7 @@ function TARDIS:HUDScreen(window)
     self.screen_in_context_menu = (window ~= nil)
 
     local screen = vgui.Create("DPanel",frame)
+    ---@diagnostic disable-next-line: assign-type-mismatch
     screen.id="pop"
     screen.width=700
     screen.height=425


### PR DESCRIPTION
Goes through the glua_ls diagnostic rule ignores in `.luarc.json` incrementally, removing them where worthwhile and documenting why the rest stay.

## Result: 1 of 5 rules enabled

Every diagnostic each rule produces was triaged. Net: `assign-type-mismatch` is now on; the other four stay off because **all of their output is false positives (zero real bugs found)**.

| Rule | Count | Decision | Why |
|---|---|---|---|
| `assign-type-mismatch` | 5 | ✅ **Enabled** | 4 `Trace.mask` fixed centrally; 1 panel marker suppressed |
| `param-type-mismatch` | 42 | ⛔ Disabled | 38 integer-enum FPs (both central fixes dead on 1.0.27) + 4 inference quirks |
| `undefined-field` | 84 | ⛔ Disabled | Metatable-OOP / runtime fields / GMod methods on untyped vars; bug-hunt found 0 typos |
| `unchecked-nil-access` | 133 | ⛔ Disabled | Entity-field flood + guard-not-narrowed; no real bugs |
| `need-check-nil` | 188 | ⛔ Disabled | Nullable entity-lookup locals used in valid-by-context spots (hint severity) |

## Changes

- **`.luarc.json`** — removed `assign-type-mismatch` from the disable list.
- **`.luatypes/glua_overrides.lua`** — replaced the dead `@alias` enum block (9 aliases, proven to do nothing on glua_ls 1.0.27) with `---@field mask integer` on `Trace`, which is what actually clears the `mask = MASK_*` warnings.
- **`lua/tardis/sh_screen_ui.lua`** — one `disable-next-line` on the `screen.id = "pop"` marker.
- **`CLAUDE.md`** — recorded the per-rule findings so the triage isn't repeated.

## Key finding

On glua_ls 1.0.27 the two central mechanisms for the integer-enum false positives are both dead: re-declaring `---@alias MASK integer` no longer overrides the stub's enum union, and `@overload`-widening a method param doesn't take either. Only direct **field widening** works — which is why `Trace.mask` was fixable but the 38 enum *params* in `param-type-mismatch` were not. If upstream restores enum-alias overriding, `param-type-mismatch` becomes worth revisiting and its 38 FPs clear at once.

`pwsh -File scripts/glua-check.ps1` passes clean (exit 0) with `assign-type-mismatch` active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0186LnDUNptRAvNbK7bBTpS1